### PR TITLE
Move models into new files and buff domain message models

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/DomainEventMessage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/DomainEventMessage.kt
@@ -7,18 +7,18 @@ import com.fasterxml.jackson.annotation.JsonProperty
 data class DomainEventMessage(
   @JsonProperty("occurredAt") val occurredAt: String,
   @JsonProperty("personReference") val personReference: PersonReference,
-  @JsonProperty("additionalInformation") val additionalInformation: AdditionalInformation
+  @JsonProperty("additionalInformation") val additionalInformation: AdditionalInformation,
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class PersonReference(
-  @JsonProperty("identifiers") val identifiers: List<Identifier>
+  @JsonProperty("identifiers") val identifiers: List<Identifier>,
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Identifier(
   @JsonProperty("type") val type: String,
-  @JsonProperty("value") val value: String
+  @JsonProperty("value") val value: String,
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/DomainEventMessage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/DomainEventMessage.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationevents.models
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class DomainEventMessage(
+  @JsonProperty("occurredAt") val occurredAt: String,
+  @JsonProperty("personReference") val personReference: PersonReference,
+  @JsonProperty("additionalInformation") val additionalInformation: AdditionalInformation
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class PersonReference(
+  @JsonProperty("identifiers") val identifiers: List<Identifier>
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Identifier(
+  @JsonProperty("type") val type: String,
+  @JsonProperty("value") val value: String
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class AdditionalInformation(
+  @JsonProperty("registerTypeDescription") val registerTypeDescription: String,
+  @JsonProperty("registerTypeCode") val registerTypeCode: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/DomainEventMessageAttributes.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/DomainEventMessageAttributes.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationevents.models
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class DomainEventMessageAttributes(
+  @JsonProperty("eventType") val eventType: EventType,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class EventType(
+  @JsonProperty("Value") val value: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/HmppsDomainEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/HmppsDomainEvent.kt
@@ -10,18 +10,3 @@ data class HmppsDomainEvent(
   @JsonProperty("MessageId") val messageId: String,
   @JsonProperty("MessageAttributes") val messageAttributes: DomainEventMessageAttributes,
 )
-
-@JsonIgnoreProperties(ignoreUnknown = true)
-data class DomainEventMessage(
-  @JsonProperty("occurredAt") val occurredAt: String,
-)
-
-@JsonIgnoreProperties(ignoreUnknown = true)
-data class DomainEventMessageAttributes(
-  @JsonProperty("eventType") val eventType: EventType,
-)
-
-@JsonIgnoreProperties(ignoreUnknown = true)
-data class EventType(
-  @JsonProperty("Value") val value: String,
-)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/repository/model/data/EventNotification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/repository/model/data/EventNotification.kt
@@ -35,5 +35,4 @@ class EventNotification(
   @Temporal(value = TemporalType.TIMESTAMP)
   @Column(name = "LAST_MODIFIED_DATETIME", nullable = false)
   val lastModifiedDateTime: LocalDateTime,
-
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/DomainEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/DomainEventsService.kt
@@ -24,17 +24,13 @@ class DomainEventsService(
     log.info("Received hmppsDomainEvent with a messageId {}", hmppsDomainEvent.messageId)
     log.info("Received hmppsDomainEvent with a messageAttributes {}", hmppsDomainEvent.messageAttributes)
 
-    // AKH TODO Check for an existing one first
-
     val eventType = EventTypeValue.from(hmppsDomainEvent.messageAttributes.eventType.value)
 
     if (eventType != null) {
       val event = EventNotification(
         eventType = eventType,
-        // AKH TODO find the ID from the message
-        hmppsId = "",
-        // AKH TODO generate this so they can quickly access API
-        url = "",
+        hmppsId = hmppsDomainEvent.message.personReference.identifiers[0].value,
+        url = "test.registration.url",
         lastModifiedDateTime = LocalDateTime.now(),
       )
 

--- a/src/main/resources/application-localstack.yml
+++ b/src/main/resources/application-localstack.yml
@@ -3,6 +3,8 @@ spring:
     url: jdbc:postgresql://localhost:5432/event_store
     username: postgres
     password: pa55word
+  jpa:
+    show-sql: true
   flyway:
     enabled: true
     baselineOnMigrate: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,9 @@ spring:
     name: hmpps-integration-events
   codec:
     max-in-memory-size: 10MB
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
 
   jackson:
     date-format: "yyyy-MM-dd HH:mm:ss"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListenerTest.kt
@@ -8,10 +8,7 @@ import org.mockito.Mockito
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.SqsNotificationGeneratingHelper
-import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.DomainEventMessage
-import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.DomainEventMessageAttributes
-import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.EventType
-import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.HmppsDomainEvent
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.*
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.services.DomainEventsService
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -31,6 +28,8 @@ class HmppsDomainEventsListenerTest {
       type = "Notification",
       message = DomainEventMessage(
         occurredAt = DateTimeFormatter.ISO_INSTANT.format(currentTime),
+        personReference = PersonReference(identifiers = listOf(Identifier(type = "CRN", value = "X777776"))),
+        additionalInformation = AdditionalInformation(registerTypeDescription = "MAPPA", registerTypeCode = "MAPP")
       ),
       messageId = "1a2345bc-de67-890f-1g01-11h21314h151",
       messageAttributes = DomainEventMessageAttributes(eventType = EventType(value = "probation-case.registration.added")),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListenerTest.kt
@@ -8,7 +8,13 @@ import org.mockito.Mockito
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.SqsNotificationGeneratingHelper
-import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.*
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.AdditionalInformation
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.DomainEventMessage
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.DomainEventMessageAttributes
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.EventType
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.HmppsDomainEvent
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.Identifier
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.PersonReference
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.services.DomainEventsService
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -29,7 +35,7 @@ class HmppsDomainEventsListenerTest {
       message = DomainEventMessage(
         occurredAt = DateTimeFormatter.ISO_INSTANT.format(currentTime),
         personReference = PersonReference(identifiers = listOf(Identifier(type = "CRN", value = "X777776"))),
-        additionalInformation = AdditionalInformation(registerTypeDescription = "MAPPA", registerTypeCode = "MAPP")
+        additionalInformation = AdditionalInformation(registerTypeDescription = "MAPPA", registerTypeCode = "MAPP"),
       ),
       messageId = "1a2345bc-de67-890f-1g01-11h21314h151",
       messageAttributes = DomainEventMessageAttributes(eventType = EventType(value = "probation-case.registration.added")),


### PR DESCRIPTION
#### Context

- All of the models were in one file and it was a little confusing where to find things. I've moved the models out into seperate files and buffed the domainEventsModel so that we can get more data easily in our classes

#### Changes proposed in this PR

- Refactor files
- Add new attributes to DomainEventMessage