### PR TITLE
added noms number as hmppsId when crn is not available.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/HmppsDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/HmppsDomainEventService.kt
@@ -40,6 +40,13 @@ class HmppsDomainEventService(
     }
   }
 
+  /**
+   * The hmpps id is an id that the end client will use in on going processing.
+   * In the future when we have a core person record it will be that id
+   * for now the id will default to the crn but if there is no crn it will be the noms number.
+   * The end client that receives the messages must treat it as a hmpps_id and NOT a crn/noms number.
+   * A look up service exist to decode the hmpps_id into a crn or noms number.
+   */
   private fun getHmppsId(hmppsEvent: HmppsDomainEventMessage): String? {
     val crn: String? = hmppsEvent.personReference?.findCrnIdentifier()
     if (crn != null) {
@@ -47,19 +54,17 @@ class HmppsDomainEventService(
         if (it.existsInDelius) {
           return crn
         }
-
         throw NotFoundException("Person with crn $crn not found")
       }
     }
+
     val nomsNumber = hmppsEvent.personReference?.findNomsIdentifier()
       ?: hmppsEvent.additionalInformation?.nomsNumber
       ?: hmppsEvent.additionalInformation?.prisonerId
 
-    nomsNumber?.let {
-      return probationIntegrationApiGateway.getPersonIdentifier(nomsNumber)?.crn ?: throw NotFoundException("Person not found nomsNumber $nomsNumber")
+    return nomsNumber?.let { noms ->
+      probationIntegrationApiGateway.getPersonIdentifier(noms)?.crn ?: noms
     }
-
-    return null
   }
 
   private fun getEventNotification(integrationEventType: IntegrationEventTypes, hmppsId: String): EventNotification? {


### PR DESCRIPTION
#### Context

Currently hmpps-integration-events fail to generate if the person does not have a CRN. 

The id on the message is the CRN but really this is a HMPPS_ID and will in future be neither a CRN nor a NOMS number and will be some representation of the core person record. For now though following discussions it has been decided that the HMPPS_ID can be either the NOMS number or CRN but should be thought of as the HMPPS_ID and then use a further Integration API call to decode the HMPPS_ID into the id the client needs (NOMS or CRN) 

Hope that makes sense. 

#### Changes proposed in this PR

-