### PR TITLE
Fix the events preprod deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ workflows:
             - hmpps-integration-events-preprod
           requires:
             - request-preprod-approval
-          helm_timeout: 15m
+          helm_timeout: 5m
       - request-prod-approval:
           type: approval
           requires:

--- a/docs/guides/setting-up-a-new-consumer.md
+++ b/docs/guides/setting-up-a-new-consumer.md
@@ -11,7 +11,9 @@ for each environment they want to access.
 
 To do this you will need the client name that you used when setting up the queue for the consumer in [Create new consumer subscriber queue for events](https://github.com/ministryofjustice/hmpps-integration-api/blob/main/docs/guides/setting-up-a-new-consumer.md#create-new-consumer-subscriber-queue-for-events). In the following instructions, replace `<client>` with your client's name, and `<CLIENT>` with the client's name in upper case. It is important that `<CLIENT>` is a case-insensitive match for `<client>`.
 
-1. In `values.yml`, add a section like the following under `namespace_secrets`
+1. If you are creating your queue in **all** environments, add the following in `values.yaml`, otherwise add the following to the `values-<environment>.yaml` for each environment you are setting up a queue. 
+
+Add a section like the following under `namespace_secrets`
 ```
 event-<client>-queue:
    <CLIENT>_QUEUE_NAME: "sqs_name"

--- a/helm_deploy/hmpps-integration-events/values.yaml
+++ b/helm_deploy/hmpps-integration-events/values.yaml
@@ -64,10 +64,6 @@ generic-service:
       PLP_QUEUE_NAME: "sqs_name"
       PLP_QUEUE_ARN: "sqs_arn"
       PLP_FILTER_POLICY_SECRET_ID: "plp_filter_policy_secret_id"
-    event-bmadley-queue:
-      BMADLEY_QUEUE_NAME: "sqs_name"
-      BMADLEY_QUEUE_ARN: "sqs_arn"
-      BMADLEY_FILTER_POLICY_SECRET_ID: "bmadley_filter_policy_secret_id"
     rds-postgresql-instance-output:
       DB_SERVER: "rds_instance_endpoint"
       DB_NAME: "database_name"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -19,6 +19,11 @@ generic-service:
     event-test-client-queue:
       TEST_CLIENT_QUEUE_NAME: "sqs_name"
       TEST_CLIENT_QUEUE_ARN: "sqs_arn"
+    event-bmadley-queue:
+      BMADLEY_QUEUE_NAME: "sqs_name"
+      BMADLEY_QUEUE_ARN: "sqs_arn"
+      BMADLEY_FILTER_POLICY_SECRET_ID: "bmadley_filter_policy_secret_id"
+
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:


### PR DESCRIPTION
The preprod deploy was failing due to missing expected kubenetes secrets. These secrets weren't required in all environments, so I've moved from `values.yaml` to `values-dev.yaml`.