### PR TITLE
Stop scheduled tasks running in test

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/HmppsIntegrationEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/HmppsIntegrationEvents.kt
@@ -2,10 +2,12 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationevents
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.context.annotation.Profile
 import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
 @EnableScheduling
+@Profile("!test")
 class HmppsIntegrationEvents
 
 fun main(args: Array<String>) {


### PR DESCRIPTION
#### Context

- At the moment, scheduled tasks (see `SubscriberService`) run during our tests. We don't want this as it tries to call endpoints which are not mocked as it runs outside of our tests. It also clutters up our test output with the errors it returns.

#### Changes proposed in this PR

- Add conditional annotation to only enable scheduled tasks to run when we aren't using the test profile