### PR TITLE
HMAI-536 Allow a single Domain Event to trigger multiple Integration Events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListener.kt
@@ -45,10 +45,10 @@ class HmppsDomainEventsListener(
 
   private fun determineEventProcess(hmppsDomainEvent: HmppsDomainEvent) {
     val hmppsEvent: HmppsDomainEventMessage = objectMapper.readValue(hmppsDomainEvent.message)
-    val matchingIntegrationEventTypes = IntegrationEventTypesFilters.filters.filter{ it.predicate.invoke(hmppsEvent) }.map { it.integrationEventType }
-      for (integrationEventType in matchingIntegrationEventTypes) {
-        hmppsDomainEventService.execute(hmppsDomainEvent, integrationEventType)
-      }
+    val matchingIntegrationEventTypes = IntegrationEventTypesFilters.filters.filter { it.predicate.invoke(hmppsEvent) }.map { it.integrationEventType }
+    for (integrationEventType in matchingIntegrationEventTypes) {
+      hmppsDomainEventService.execute(hmppsDomainEvent, integrationEventType)
+    }
   }
 
   fun unwrapSqsExceptions(e: Throwable): Throwable {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListener.kt
@@ -45,12 +45,10 @@ class HmppsDomainEventsListener(
 
   private fun determineEventProcess(hmppsDomainEvent: HmppsDomainEvent) {
     val hmppsEvent: HmppsDomainEventMessage = objectMapper.readValue(hmppsDomainEvent.message)
-    val matchingIntegrationEventTypes = IntegrationEventTypesFilters.filters.filter{ it.predicate.invoke(hmppsEvent) }.map { it.integrationEventTypes }
-    if (matchingIntegrationEventTypes.isNotEmpty()) {
+    val matchingIntegrationEventTypes = IntegrationEventTypesFilters.filters.filter{ it.predicate.invoke(hmppsEvent) }.map { it.integrationEventType }
       for (integrationEventType in matchingIntegrationEventTypes) {
         hmppsDomainEventService.execute(hmppsDomainEvent, integrationEventType)
       }
-    }
   }
 
   fun unwrapSqsExceptions(e: Throwable): Throwable {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListener.kt
@@ -45,9 +45,11 @@ class HmppsDomainEventsListener(
 
   private fun determineEventProcess(hmppsDomainEvent: HmppsDomainEvent) {
     val hmppsEvent: HmppsDomainEventMessage = objectMapper.readValue(hmppsDomainEvent.message)
-    val integrationEventType = IntegrationEventTypesFilters.filters.firstOrNull { it.predicate.invoke(hmppsEvent) }?.integrationEventTypes
-    if (integrationEventType != null) {
-      hmppsDomainEventService.execute(hmppsDomainEvent, integrationEventType)
+    val matchingIntegrationEventTypes = IntegrationEventTypesFilters.filters.filter{ it.predicate.invoke(hmppsEvent) }.map { it.integrationEventTypes }
+    if (matchingIntegrationEventTypes.isNotEmpty()) {
+      for (integrationEventType in matchingIntegrationEventTypes) {
+        hmppsDomainEventService.execute(hmppsDomainEvent, integrationEventType)
+      }
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/enums/IntegrationEventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/enums/IntegrationEventType.kt
@@ -126,7 +126,7 @@ object RegisterTypes {
   const val WARRANT_SUMMONS_CODE = "WRSM" // Outstanding warrant or summons
 }
 
-enum class IntegrationEventTypes(val value: String, private val pathTemplate: String) {
+enum class IntegrationEventType(val value: String, private val pathTemplate: String) {
   DYNAMIC_RISKS_CHANGED("DynamicRisks.Changed", "v1/persons/{hmppsId}/risks/dynamic"),
   PROBATION_STATUS_CHANGED("ProbationStatus.Changed", "v1/persons/{hmppsId}/status-information"),
   MAPPA_DETAIL_CHANGED("MappaDetail.Changed", "v1/persons/{hmppsId}/risks/mappadetail"),
@@ -148,8 +148,8 @@ enum class IntegrationEventTypes(val value: String, private val pathTemplate: St
   fun path(hmppsId: String) = pathTemplate.replace("{hmppsId}", hmppsId)
 
   companion object {
-    fun from(eventType: IntegrationEventTypes): IntegrationEventTypes? =
-      IntegrationEventTypes.entries.firstOrNull {
+    fun from(eventType: IntegrationEventType): IntegrationEventType? =
+      IntegrationEventType.entries.firstOrNull {
         it.value == eventType.value
       }
   }
@@ -157,49 +157,49 @@ enum class IntegrationEventTypes(val value: String, private val pathTemplate: St
 
 object IntegrationEventTypesFilters {
   val filters: List<IntegrationEventTypesFilter> = listOf(
-    IntegrationEventTypesFilter(IntegrationEventTypes.DYNAMIC_RISKS_CHANGED) {
+    IntegrationEventTypesFilter(IntegrationEventType.DYNAMIC_RISKS_CHANGED) {
       DYNAMIC_RISK_EVENTS.contains(it.eventType) && DYNAMIC_RISKS_REGISTER_TYPES.contains(it.additionalInformation!!.registerTypeCode)
     },
-    IntegrationEventTypesFilter(IntegrationEventTypes.PROBATION_STATUS_CHANGED) {
+    IntegrationEventTypesFilter(IntegrationEventType.PROBATION_STATUS_CHANGED) {
       PROBATION_STATUS_CHANGED_EVENTS.contains(it.eventType) && PROBATION_STATUS_REGISTER_TYPES.contains(it.additionalInformation!!.registerTypeCode)
     },
-    IntegrationEventTypesFilter(IntegrationEventTypes.MAPPA_DETAIL_CHANGED) {
+    IntegrationEventTypesFilter(IntegrationEventType.MAPPA_DETAIL_CHANGED) {
       MAPPA_DETAIL_REGISTER_EVENTS.contains(it.eventType) && MAPPA_DETAIL_REGISTER_TYPES.contains(it.additionalInformation!!.registerTypeCode)
     },
-    IntegrationEventTypesFilter(IntegrationEventTypes.RISK_SCORE_CHANGED, {
+    IntegrationEventTypesFilter(IntegrationEventType.RISK_SCORE_CHANGED, {
       RISK_SCORE_TYPES.contains(it.eventType)
     }),
-    IntegrationEventTypesFilter(IntegrationEventTypes.KEY_DATES_AND_ADJUSTMENTS_PRISONER_RELEASE) {
+    IntegrationEventTypesFilter(IntegrationEventType.KEY_DATES_AND_ADJUSTMENTS_PRISONER_RELEASE) {
       KEY_DATES_AND_ADJUSTMENTS_PRISONER_RELEASE_EVENTS.contains(it.eventType)
     },
-    IntegrationEventTypesFilter(IntegrationEventTypes.PERSON_STATUS_CHANGED) {
+    IntegrationEventTypesFilter(IntegrationEventType.PERSON_STATUS_CHANGED) {
       PERSON_EVENTS.contains(it.eventType)
     },
-    IntegrationEventTypesFilter(IntegrationEventTypes.PND_ALERTS_CHANGED) {
+    IntegrationEventTypesFilter(IntegrationEventType.PND_ALERTS_CHANGED) {
       PND_ALERT_EVENTS.contains(it.eventType) && PND_ALERT_TYPES.contains(it.additionalInformation!!.alertCode)
     },
-    IntegrationEventTypesFilter(IntegrationEventTypes.LICENCE_CONDITION_CHANGED) {
+    IntegrationEventTypesFilter(IntegrationEventType.LICENCE_CONDITION_CHANGED) {
       LICENCE_CONDITION_EVENTS.contains(it.eventType)
     },
-    IntegrationEventTypesFilter(IntegrationEventTypes.RISK_OF_SERIOUS_HARM_CHANGED) {
+    IntegrationEventTypesFilter(IntegrationEventType.RISK_OF_SERIOUS_HARM_CHANGED) {
       ROSH_TYPES.contains(it.eventType)
     },
-    IntegrationEventTypesFilter(IntegrationEventTypes.PLP_INDUCTION_SCHEDULE_CHANGED) {
+    IntegrationEventTypesFilter(IntegrationEventType.PLP_INDUCTION_SCHEDULE_CHANGED) {
       PLP_INDUCTION_SCHEDULE_EVENT.contains(it.eventType)
     },
-    IntegrationEventTypesFilter(IntegrationEventTypes.PLP_REVIEW_SCHEDULE_CHANGED) {
+    IntegrationEventTypesFilter(IntegrationEventType.PLP_REVIEW_SCHEDULE_CHANGED) {
       PLP_REVIEW_SCHEDULE_EVENT.contains(it.eventType)
     },
-    IntegrationEventTypesFilter(IntegrationEventTypes.PERSON_ADDRESS_CHANGED) {
+    IntegrationEventTypesFilter(IntegrationEventType.PERSON_ADDRESS_CHANGED) {
       PERSON_ADDRESS_EVENTS.contains(it.eventType)
     },
-    IntegrationEventTypesFilter(IntegrationEventTypes.RESPONSIBLE_OFFICER_CHANGED) {
+    IntegrationEventTypesFilter(IntegrationEventType.RESPONSIBLE_OFFICER_CHANGED) {
       RESPONSIBLE_OFFICER_EVENTS.contains(it.eventType)
     },
   )
 }
 
 data class IntegrationEventTypesFilter(
-  val integrationEventTypes: IntegrationEventTypes,
+  val integrationEventType: IntegrationEventType,
   val predicate: (HmppsDomainEventMessage) -> Boolean,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/enums/IntegrationEventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/enums/IntegrationEventType.kt
@@ -75,6 +75,13 @@ val PND_ALERT_EVENTS = listOf(
   "person.alert.updated",
 )
 
+val ALERT_EVENTS = listOf(
+  "person.alert.created",
+  "person.alert.changed",
+  "person.alert.deleted",
+  "person.alert.updated",
+)
+
 val LICENCE_CONDITION_EVENTS =
   listOf("create-and-vary-a-licence.licence.activated", "create-and-vary-a-licence.licence.inactivated")
 
@@ -137,6 +144,7 @@ enum class IntegrationEventType(val value: String, private val pathTemplate: Str
   ),
   PERSON_STATUS_CHANGED("PersonStatus.Changed", "v1/persons/{hmppsId}"),
   PND_ALERTS_CHANGED("PNDAlerts.Changed", "v1/pnd/persons/{hmppsId}/alerts"),
+  ALERTS_CHANGED("Alerts.Changed", "v1/persons/{hmppsId}/alerts"),
   LICENCE_CONDITION_CHANGED("LicenceCondition.Changed", "v1/persons/{hmppsId}/licences/conditions"),
   RISK_OF_SERIOUS_HARM_CHANGED("RiskOfSeriousHarm.Changed", "v1/persons/{hmppsId}/risks/serious-harm"),
   PLP_INDUCTION_SCHEDULE_CHANGED("PLPInductionSchedule.Changed", "v1/persons/{hmppsId}/plp-induction-schedule/history"),
@@ -177,6 +185,9 @@ object IntegrationEventTypesFilters {
     },
     IntegrationEventTypesFilter(IntegrationEventType.PND_ALERTS_CHANGED) {
       PND_ALERT_EVENTS.contains(it.eventType) && PND_ALERT_TYPES.contains(it.additionalInformation!!.alertCode)
+    },
+    IntegrationEventTypesFilter(IntegrationEventType.ALERTS_CHANGED) {
+      ALERT_EVENTS.contains(it.eventType)
     },
     IntegrationEventTypesFilter(IntegrationEventType.LICENCE_CONDITION_CHANGED) {
       LICENCE_CONDITION_EVENTS.contains(it.eventType)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/enums/IntegrationEventTypes.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/enums/IntegrationEventTypes.kt
@@ -166,9 +166,9 @@ object IntegrationEventTypesFilters {
     IntegrationEventTypesFilter(IntegrationEventTypes.MAPPA_DETAIL_CHANGED) {
       MAPPA_DETAIL_REGISTER_EVENTS.contains(it.eventType) && MAPPA_DETAIL_REGISTER_TYPES.contains(it.additionalInformation!!.registerTypeCode)
     },
-    IntegrationEventTypesFilter(IntegrationEventTypes.RISK_SCORE_CHANGED) {
+    IntegrationEventTypesFilter(IntegrationEventTypes.RISK_SCORE_CHANGED, {
       RISK_SCORE_TYPES.contains(it.eventType)
-    },
+    }),
     IntegrationEventTypesFilter(IntegrationEventTypes.KEY_DATES_AND_ADJUSTMENTS_PRISONER_RELEASE) {
       KEY_DATES_AND_ADJUSTMENTS_PRISONER_RELEASE_EVENTS.contains(it.eventType)
     },

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/repository/EventNotificationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/repository/EventNotificationRepository.kt
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
-import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventTypes
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventType
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.repository.model.data.EventNotification
 import java.time.LocalDateTime
 
@@ -17,13 +17,13 @@ interface EventNotificationRepository : JpaRepository<EventNotification, Long> {
     @Param("dateTime") dateTime: LocalDateTime?,
   ): List<EventNotification>
 
-  fun existsByHmppsIdAndEventType(hmppsId: String, eventType: IntegrationEventTypes): Boolean
+  fun existsByHmppsIdAndEventType(hmppsId: String, eventType: IntegrationEventType): Boolean
 
   @Modifying
   @Query("update EventNotification e set e.lastModifiedDateTime = :dateTime where e.hmppsId = :hmppsId and e.eventType = :eventType")
   fun updateLastModifiedDateTimeByHmppsIdAndEventType(
-    @Param("dateTime") dateTime: LocalDateTime,
-    @Param("hmppsId") hmppsId: String,
-    @Param("eventType") eventType: IntegrationEventTypes,
+      @Param("dateTime") dateTime: LocalDateTime,
+      @Param("hmppsId") hmppsId: String,
+      @Param("eventType") eventType: IntegrationEventType,
   ): Int
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/repository/EventNotificationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/repository/EventNotificationRepository.kt
@@ -22,8 +22,8 @@ interface EventNotificationRepository : JpaRepository<EventNotification, Long> {
   @Modifying
   @Query("update EventNotification e set e.lastModifiedDateTime = :dateTime where e.hmppsId = :hmppsId and e.eventType = :eventType")
   fun updateLastModifiedDateTimeByHmppsIdAndEventType(
-      @Param("dateTime") dateTime: LocalDateTime,
-      @Param("hmppsId") hmppsId: String,
-      @Param("eventType") eventType: IntegrationEventType,
+    @Param("dateTime") dateTime: LocalDateTime,
+    @Param("hmppsId") hmppsId: String,
+    @Param("eventType") eventType: IntegrationEventType,
   ): Int
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/repository/model/data/EventNotification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/repository/model/data/EventNotification.kt
@@ -10,29 +10,29 @@ import jakarta.persistence.Id
 import jakarta.persistence.Table
 import jakarta.persistence.Temporal
 import jakarta.persistence.TemporalType
-import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventTypes
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventType
 import java.time.LocalDateTime
 
 @Entity
 @Table(name = "EVENT_NOTIFICATION")
 data class EventNotification(
 
-  @Id
+    @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "EVENT_ID", nullable = false, unique = true)
   val eventId: Long? = null,
 
-  @Column(name = "HMPPS_ID", nullable = false)
+    @Column(name = "HMPPS_ID", nullable = false)
   val hmppsId: String,
 
-  @Enumerated(EnumType.STRING)
+    @Enumerated(EnumType.STRING)
   @Column(name = "EVENT_TYPE", nullable = false)
-  val eventType: IntegrationEventTypes,
+  val eventType: IntegrationEventType,
 
-  @Column(name = "URL", nullable = false)
+    @Column(name = "URL", nullable = false)
   val url: String,
 
-  @Temporal(value = TemporalType.TIMESTAMP)
+    @Temporal(value = TemporalType.TIMESTAMP)
   @Column(name = "LAST_MODIFIED_DATETIME", nullable = false)
   val lastModifiedDateTime: LocalDateTime,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/repository/model/data/EventNotification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/repository/model/data/EventNotification.kt
@@ -17,22 +17,22 @@ import java.time.LocalDateTime
 @Table(name = "EVENT_NOTIFICATION")
 data class EventNotification(
 
-    @Id
+  @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "EVENT_ID", nullable = false, unique = true)
   val eventId: Long? = null,
 
-    @Column(name = "HMPPS_ID", nullable = false)
+  @Column(name = "HMPPS_ID", nullable = false)
   val hmppsId: String,
 
-    @Enumerated(EnumType.STRING)
+  @Enumerated(EnumType.STRING)
   @Column(name = "EVENT_TYPE", nullable = false)
   val eventType: IntegrationEventType,
 
-    @Column(name = "URL", nullable = false)
+  @Column(name = "URL", nullable = false)
   val url: String,
 
-    @Temporal(value = TemporalType.TIMESTAMP)
+  @Temporal(value = TemporalType.TIMESTAMP)
   @Column(name = "LAST_MODIFIED_DATETIME", nullable = false)
   val lastModifiedDateTime: LocalDateTime,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/HmppsDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/HmppsDomainEventService.kt
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.exceptions.NotFoundException
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.gateway.ProbationIntegrationApiGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.HmppsDomainEvent
-import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventTypes
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventType
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.registration.HmppsDomainEventMessage
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.repository.EventNotificationRepository
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.repository.model.data.EventNotification
@@ -25,7 +25,7 @@ class HmppsDomainEventService(
 ) {
   private val objectMapper = ObjectMapper()
 
-  fun execute(hmppsDomainEvent: HmppsDomainEvent, eventType: IntegrationEventTypes) {
+  fun execute(hmppsDomainEvent: HmppsDomainEvent, eventType: IntegrationEventType) {
     val hmppsEvent: HmppsDomainEventMessage = objectMapper.readValue(hmppsDomainEvent.message)
     val hmppsId = getHmppsId(hmppsEvent)
 
@@ -67,8 +67,8 @@ class HmppsDomainEventService(
     }
   }
 
-  private fun getEventNotification(integrationEventType: IntegrationEventTypes, hmppsId: String): EventNotification? {
-    val eventType = IntegrationEventTypes.from(integrationEventType)
+  private fun getEventNotification(integrationEventType: IntegrationEventType, hmppsId: String): EventNotification? {
+    val eventType = IntegrationEventType.from(integrationEventType)
     if (eventType != null) {
       return EventNotification(
         eventType = eventType,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/SubscriberService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/SubscriberService.kt
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.config.HmppsSecretManagerProperties
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.gateway.IntegrationApiGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.SubscriberFilterList
-import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventTypes
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventType
 
 @Service
 class SubscriberService(
@@ -30,20 +30,20 @@ class SubscriberService(
     val events = clientConfig.value
       .flatMap { url ->
         listOfNotNull(
-          url.takeIf { it.contains("/v1/persons/.*/risks/mappadetail") }?.let { IntegrationEventTypes.MAPPA_DETAIL_CHANGED.name },
-          url.takeIf { it.contains("/v1/persons/.*/risks/scores") }?.let { IntegrationEventTypes.RISK_SCORE_CHANGED.name },
-          url.takeIf { it.contains("/v1/persons/.*/sentences/latest-key-dates-and-adjustments") }?.let { IntegrationEventTypes.KEY_DATES_AND_ADJUSTMENTS_PRISONER_RELEASE.name },
-          url.takeIf { it.contains("/v1/persons/.*/status-information") }?.let { IntegrationEventTypes.PROBATION_STATUS_CHANGED.name },
-          url.takeIf { it.contains("/v1/persons/.*/risks/dynamic") }?.let { IntegrationEventTypes.DYNAMIC_RISKS_CHANGED.name },
-          url.takeIf { it.contains("/v1/persons/[^/]*$") }?.let { IntegrationEventTypes.PERSON_STATUS_CHANGED.name },
-          url.takeIf { it.contains("/v1/persons/.*/alerts/pnd") }?.let { IntegrationEventTypes.PND_ALERTS_CHANGED.name },
-          url.takeIf { it.contains("/v1/pnd/persons/.*/alerts") }?.let { IntegrationEventTypes.PND_ALERTS_CHANGED.name },
-          url.takeIf { it.contains("/v1/persons/.*/licences/conditions") }?.let { IntegrationEventTypes.LICENCE_CONDITION_CHANGED.name },
-          url.takeIf { it.contains("/v1/persons/.*/risks/serious-harm") }?.let { IntegrationEventTypes.RISK_OF_SERIOUS_HARM_CHANGED.name },
-          url.takeIf { it.contains("/v1/persons/.*/plp-induction-schedule") }?.let { IntegrationEventTypes.PLP_INDUCTION_SCHEDULE_CHANGED.name },
-          url.takeIf { it.contains("/v1/persons/.*/plp-review-schedule") }?.let { IntegrationEventTypes.PLP_REVIEW_SCHEDULE_CHANGED.name },
-          url.takeIf { it.contains("/v1/persons/.*/addresses") }?.let { IntegrationEventTypes.PERSON_ADDRESS_CHANGED.name },
-          url.takeIf { it.contains("/v1/persons/.*/person-responsible-officer") }?.let { IntegrationEventTypes.RESPONSIBLE_OFFICER_CHANGED.name },
+          url.takeIf { it.contains("/v1/persons/.*/risks/mappadetail") }?.let { IntegrationEventType.MAPPA_DETAIL_CHANGED.name },
+          url.takeIf { it.contains("/v1/persons/.*/risks/scores") }?.let { IntegrationEventType.RISK_SCORE_CHANGED.name },
+          url.takeIf { it.contains("/v1/persons/.*/sentences/latest-key-dates-and-adjustments") }?.let { IntegrationEventType.KEY_DATES_AND_ADJUSTMENTS_PRISONER_RELEASE.name },
+          url.takeIf { it.contains("/v1/persons/.*/status-information") }?.let { IntegrationEventType.PROBATION_STATUS_CHANGED.name },
+          url.takeIf { it.contains("/v1/persons/.*/risks/dynamic") }?.let { IntegrationEventType.DYNAMIC_RISKS_CHANGED.name },
+          url.takeIf { it.contains("/v1/persons/[^/]*$") }?.let { IntegrationEventType.PERSON_STATUS_CHANGED.name },
+          url.takeIf { it.contains("/v1/persons/.*/alerts/pnd") }?.let { IntegrationEventType.PND_ALERTS_CHANGED.name },
+          url.takeIf { it.contains("/v1/pnd/persons/.*/alerts") }?.let { IntegrationEventType.PND_ALERTS_CHANGED.name },
+          url.takeIf { it.contains("/v1/persons/.*/licences/conditions") }?.let { IntegrationEventType.LICENCE_CONDITION_CHANGED.name },
+          url.takeIf { it.contains("/v1/persons/.*/risks/serious-harm") }?.let { IntegrationEventType.RISK_OF_SERIOUS_HARM_CHANGED.name },
+          url.takeIf { it.contains("/v1/persons/.*/plp-induction-schedule") }?.let { IntegrationEventType.PLP_INDUCTION_SCHEDULE_CHANGED.name },
+          url.takeIf { it.contains("/v1/persons/.*/plp-review-schedule") }?.let { IntegrationEventType.PLP_REVIEW_SCHEDULE_CHANGED.name },
+          url.takeIf { it.contains("/v1/persons/.*/addresses") }?.let { IntegrationEventType.PERSON_ADDRESS_CHANGED.name },
+          url.takeIf { it.contains("/v1/persons/.*/person-responsible-officer") }?.let { IntegrationEventType.RESPONSIBLE_OFFICER_CHANGED.name },
         )
       }
       .ifEmpty { listOf("DEFAULT") }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/helpers/SqsNotificationGeneratingHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/helpers/SqsNotificationGeneratingHelper.kt
@@ -103,6 +103,32 @@ class SqsNotificationGeneratingHelper(timestamp: ZonedDateTime = LocalDateTime.n
     """
     )
 
+  fun generateRawHmppsDomainEventWithAlertCode(
+    eventType: String,
+    identifiers: String = "[{\\\"type\\\":\\\"CRN\\\",\\\"value\\\":\\\"X777776\\\"}]",
+    messageEventType: String = eventType,
+    alertCode: String,
+  ): String = (
+    """
+    {
+     "Type" : "Notification",
+     "MessageId" : "1a2345bc-de67-890f-1g01-11h21314h151",
+     "TopicArn" : "arn:aws:sns:eu-west-2:123456789123:cloud-platform-Digital-Prison-Services-12a3456bc12345a1a12345ab3c123b12",
+     "Message" : "{\"eventType\":\"$messageEventType\",\"version\":1,\"occurredAt\":\"$isoInstantTimestamp\",\"description\":\"A new registration has been added to the probation case\",\"personReference\":{\"identifiers\":$identifiers},\"additionalInformation\":{\"registrationLevelDescription\":\"MAPPA Level 3\",\"registerTypeDescription\":\"MAPPA\",\"registrationCategoryCode\":\"M1\",\"alertCode\":\"$alertCode\",\"registrationId\":\"1234567890\",\"registrationDate\":\"$readableTimestamp\",\"createdDateAndTime\":\"$readableTimestamp\",\"registrationCategoryDescription\":\"MAPPA Cat 1\",\"registrationLevelCode\":\"M3\"}}",
+     "Timestamp" : "$isoInstantTimestamp",
+     "SignatureVersion" : "1",
+     "Signature" : "A5cK8hNQj+3PTeLwS9D4bFYUvz1aI6cGvT2XWmRkE+7MoJZniFQjDeo2tI3BwKhLI9RXznGvZD1KbOoEMp4kUqBnA2Wr3bH5D6NfYhJKYV8sGpVcWzUMlTgbxErC1L7RgM2o7bHWlCKqfzOiDRsLpPeuJElmuTcYJtn+Lxv3R4TyYndafQSoVpErHcRJwWjDSf5l6jrKVa4m0NQbgtyZlxVPcHYf+wpWcuJ1BvLSnDHM+egRw7GqpxDB+IU1kEolC3eL4RUjXGmkQ9YtczF2P1JrThsRi0oEgnp7f/VtB6oqOKkYvlMXaF/+uhdwZbWlDa/83HcYV9MkJpWpx8UeisflEMNt57hbJXIgGQvsTYo4cRn9VgWQJxb6yDw8zS+I6yuGNbcL5L2Aj+whsEM1ovcR7KBPvgsMlxtCyVYzj36sDa4nUfiR5iZkVDeT==",
+     "SigningCertURL" : "https://sns.eu-west-2.amazonaws.com/SimpleNotificationService-12abcd123456d12b1e23a123456ef123.pem",
+     "UnsubscribeURL" : "https://sns.eu-west-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-2:123456789123:cloud-platform-Digital-Prison-Services-12a3456bc12345a1a12345ab3c123b12:123b456a-123f-1234-a123-123456789d10",
+     "MessageAttributes" : {
+       "eventType" : {"Type":"String","Value":"$eventType"},
+       "id" : {"Type":"String","Value":"12345678-a1af-a0ba-1b22-d12e12d1234f"},
+       "timestamp" : {"Type":"Number.java.lang.Long","Value":"$millis"}
+     }
+    }
+    """
+    )
+
   fun createHmppsDomainEvent(
     eventType: String = "probation-case.registration.added",
     registerTypeCode: String = "MAPP",
@@ -125,6 +151,20 @@ class SqsNotificationGeneratingHelper(timestamp: ZonedDateTime = LocalDateTime.n
     HmppsDomainEvent(
       type = "Notification",
       message = "{\"eventType\":\"$eventType\",\"version\":1,\"occurredAt\":\"$isoInstantTimestamp\",\"description\":\"A new registration has been added to the probation case\",\"personReference\":{\"identifiers\":$identifiers},\"additionalInformation\":{\"registrationLevelDescription\":\"MAPPA Level 3\",\"registerTypeDescription\":\"MAPPA\",\"registrationCategoryCode\":\"M1\",\"registrationId\":\"1234567890\",\"registrationDate\":\"$readableTimestamp\",\"createdDateAndTime\":\"$readableTimestamp\",\"registrationCategoryDescription\":\"MAPPA Cat 1\",\"registrationLevelCode\":\"M3\"}}",
+      messageId = "1a2345bc-de67-890f-1g01-11h21314h151",
+      messageAttributes = DomainEventMessageAttributes(eventType = EventType(value = attributeEventTypes)),
+    )
+    )
+
+  fun createHmppsDomainEventWithAlertCode(
+    eventType: String,
+    identifiers: String = "[{\"type\":\"CRN\",\"value\":\"X777776\"}]",
+    attributeEventTypes: String = eventType,
+    alertCode: String,
+  ): HmppsDomainEvent = (
+    HmppsDomainEvent(
+      type = "Notification",
+      message = "{\"eventType\":\"$eventType\",\"version\":1,\"occurredAt\":\"$isoInstantTimestamp\",\"description\":\"A new registration has been added to the probation case\",\"personReference\":{\"identifiers\":$identifiers},\"additionalInformation\":{\"registrationLevelDescription\":\"MAPPA Level 3\",\"registerTypeDescription\":\"MAPPA\",\"registrationCategoryCode\":\"M1\",\"alertCode\":\"$alertCode\",\"registrationId\":\"1234567890\",\"registrationDate\":\"$readableTimestamp\",\"createdDateAndTime\":\"$readableTimestamp\",\"registrationCategoryDescription\":\"MAPPA Cat 1\",\"registrationLevelCode\":\"M3\"}}",
       messageId = "1a2345bc-de67-890f-1g01-11h21314h151",
       messageAttributes = DomainEventMessageAttributes(eventType = EventType(value = attributeEventTypes)),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/listeners/HmppsDomainEventsListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/listeners/HmppsDomainEventsListenerIntegrationTest.kt
@@ -13,7 +13,7 @@ import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.SqsNotificationGeneratingHelper
-import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventTypes
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventType
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.repository.EventNotificationRepository
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.resources.SqsIntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.resources.wiremock.HmppsAuthExtension
@@ -54,7 +54,7 @@ class HmppsDomainEventsListenerIntegrationTest : SqsIntegrationTestBase() {
     Awaitility.await().until { repo.findAll().isNotEmpty() }
     val savedEvent = repo.findAll().firstOrNull()
     savedEvent.shouldNotBeNull()
-    savedEvent.eventType.shouldBe(IntegrationEventTypes.KEY_DATES_AND_ADJUSTMENTS_PRISONER_RELEASE)
+    savedEvent.eventType.shouldBe(IntegrationEventType.KEY_DATES_AND_ADJUSTMENTS_PRISONER_RELEASE)
     savedEvent.hmppsId.shouldBe("mockCrn")
     savedEvent.url.shouldBe("https://localhost:8443/v1/persons/mockCrn/sentences/latest-key-dates-and-adjustments")
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/services/IntegrationEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/services/IntegrationEventTest.kt
@@ -20,7 +20,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
 import software.amazon.awssdk.services.sqs.model.Message
 import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
-import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventTypes
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventType
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.repository.EventNotificationRepository
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.repository.model.data.EventNotification
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.services.IntegrationEventTopicService
@@ -91,7 +91,7 @@ class IntegrationEventTest {
     await.atMost(5, TimeUnit.SECONDS).untilAsserted {
       eventRepository.save(
         EventNotification(
-          eventType = IntegrationEventTypes.MAPPA_DETAIL_CHANGED,
+          eventType = IntegrationEventType.MAPPA_DETAIL_CHANGED,
           hmppsId = "MockId",
           url = "MockUrl",
           lastModifiedDateTime = LocalDateTime.now().minusMinutes(6),
@@ -105,7 +105,7 @@ class IntegrationEventTest {
           ThrowingConsumer { event: String? ->
             JsonAssertions.assertThatJson(event)
               .node("eventType")
-              .isEqualTo(IntegrationEventTypes.MAPPA_DETAIL_CHANGED.name)
+              .isEqualTo(IntegrationEventType.MAPPA_DETAIL_CHANGED.name)
           },
         )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/AddressChangedEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/AddressChangedEventTest.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.params.provider.ValueSource
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents.crn
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents.generateHmppsDomainEvent
-import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventTypes
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventType
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.services.DeadLetterQueueService
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.services.HmppsDomainEventService
 
@@ -40,7 +40,7 @@ class AddressChangedEventTest {
     every {
       hmppsDomainEventService.execute(
         hmppsDomainEvent,
-        IntegrationEventTypes.PERSON_ADDRESS_CHANGED,
+        IntegrationEventType.PERSON_ADDRESS_CHANGED,
       )
     } just runs
 
@@ -49,7 +49,7 @@ class AddressChangedEventTest {
     verify(exactly = 1) {
       hmppsDomainEventService.execute(
         hmppsDomainEvent,
-        IntegrationEventTypes.PERSON_ADDRESS_CHANGED,
+        IntegrationEventType.PERSON_ADDRESS_CHANGED,
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListenerLicenceConditionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListenerLicenceConditionTest.kt
@@ -11,7 +11,7 @@ import org.springframework.boot.test.autoconfigure.json.JsonTest
 import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents.generateHmppsDomainEvent
-import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventTypes
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventType
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.services.DeadLetterQueueService
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.services.HmppsDomainEventService
 
@@ -42,10 +42,10 @@ class HmppsDomainEventsListenerLicenceConditionTest {
     val payload = DomainEvents.generateDomainEvent(eventType, message)
     val hmppsDomainEvent = generateHmppsDomainEvent(eventType, hmppsMessage)
 
-    every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventTypes.LICENCE_CONDITION_CHANGED) } just runs
+    every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.LICENCE_CONDITION_CHANGED) } just runs
 
     hmppsDomainEventsListener.onDomainEvent(payload)
 
-    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventTypes.LICENCE_CONDITION_CHANGED) }
+    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.LICENCE_CONDITION_CHANGED) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListenerPLPInductionUpdatedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListenerPLPInductionUpdatedTest.kt
@@ -10,7 +10,7 @@ import org.springframework.boot.test.autoconfigure.json.JsonTest
 import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents.generateHmppsDomainEvent
-import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventTypes
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventType
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.services.DeadLetterQueueService
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.services.HmppsDomainEventService
 
@@ -36,10 +36,10 @@ class HmppsDomainEventsListenerPLPInductionUpdatedTest {
     val payload = DomainEvents.generateDomainEvent(eventType, message)
     val hmppsDomainEvent = generateHmppsDomainEvent(eventType, hmppsMessage)
 
-    every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventTypes.PLP_INDUCTION_SCHEDULE_CHANGED) } just runs
+    every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.PLP_INDUCTION_SCHEDULE_CHANGED) } just runs
 
     hmppsDomainEventsListener.onDomainEvent(payload)
 
-    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventTypes.PLP_INDUCTION_SCHEDULE_CHANGED) }
+    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.PLP_INDUCTION_SCHEDULE_CHANGED) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListenerPLPReviewUpdatedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListenerPLPReviewUpdatedTest.kt
@@ -10,7 +10,7 @@ import org.springframework.boot.test.autoconfigure.json.JsonTest
 import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents.generateHmppsDomainEvent
-import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventTypes
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventType
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.services.DeadLetterQueueService
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.services.HmppsDomainEventService
 
@@ -36,10 +36,10 @@ class HmppsDomainEventsListenerPLPReviewUpdatedTest {
     val payload = DomainEvents.generateDomainEvent(eventType, message)
     val hmppsDomainEvent = generateHmppsDomainEvent(eventType, hmppsMessage)
 
-    every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventTypes.PLP_REVIEW_SCHEDULE_CHANGED) } just runs
+    every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.PLP_REVIEW_SCHEDULE_CHANGED) } just runs
 
     hmppsDomainEventsListener.onDomainEvent(payload)
 
-    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventTypes.PLP_REVIEW_SCHEDULE_CHANGED) }
+    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.PLP_REVIEW_SCHEDULE_CHANGED) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListenerPNDAlertsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListenerPNDAlertsTest.kt
@@ -50,6 +50,7 @@ class HmppsDomainEventsListenerPNDAlertsTest {
 
     verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.PND_ALERTS_CHANGED) }
     verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.ALERTS_CHANGED) }
+    verify(exactly = 2) { hmppsDomainEventService.execute(any(), any()) }
   }
 
   @ParameterizedTest
@@ -77,6 +78,7 @@ class HmppsDomainEventsListenerPNDAlertsTest {
 
     verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.PND_ALERTS_CHANGED) }
     verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.ALERTS_CHANGED) }
+    verify(exactly = 2) { hmppsDomainEventService.execute(any(), any()) }
   }
 
   @ParameterizedTest
@@ -104,6 +106,7 @@ class HmppsDomainEventsListenerPNDAlertsTest {
 
     verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.PND_ALERTS_CHANGED) }
     verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.ALERTS_CHANGED) }
+    verify(exactly = 2) { hmppsDomainEventService.execute(any(), any()) }
   }
 
   @ParameterizedTest
@@ -131,5 +134,6 @@ class HmppsDomainEventsListenerPNDAlertsTest {
 
     verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.PND_ALERTS_CHANGED) }
     verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.ALERTS_CHANGED) }
+    verify(exactly = 2) { hmppsDomainEventService.execute(any(), any()) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListenerPNDAlertsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListenerPNDAlertsTest.kt
@@ -11,7 +11,7 @@ import org.springframework.boot.test.autoconfigure.json.JsonTest
 import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents.generateHmppsDomainEvent
-import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventTypes
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventType
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.services.DeadLetterQueueService
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.services.HmppsDomainEventService
 
@@ -43,11 +43,11 @@ class HmppsDomainEventsListenerPNDAlertsTest {
     val payload = DomainEvents.generateDomainEvent(eventType, message)
     val hmppsDomainEvent = generateHmppsDomainEvent(eventType, hmppsMessage)
 
-    every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventTypes.PND_ALERTS_CHANGED) } just runs
+    every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.PND_ALERTS_CHANGED) } just runs
 
     hmppsDomainEventsListener.onDomainEvent(payload)
 
-    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventTypes.PND_ALERTS_CHANGED) }
+    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.PND_ALERTS_CHANGED) }
   }
 
   @ParameterizedTest
@@ -68,11 +68,11 @@ class HmppsDomainEventsListenerPNDAlertsTest {
     val payload = DomainEvents.generateDomainEvent(eventType, message)
     val hmppsDomainEvent = generateHmppsDomainEvent(eventType, hmppsMessage)
 
-    every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventTypes.PND_ALERTS_CHANGED) } just runs
+    every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.PND_ALERTS_CHANGED) } just runs
 
     hmppsDomainEventsListener.onDomainEvent(payload)
 
-    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventTypes.PND_ALERTS_CHANGED) }
+    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.PND_ALERTS_CHANGED) }
   }
 
   @ParameterizedTest
@@ -93,11 +93,11 @@ class HmppsDomainEventsListenerPNDAlertsTest {
     val payload = DomainEvents.generateDomainEvent(eventType, message)
     val hmppsDomainEvent = generateHmppsDomainEvent(eventType, hmppsMessage)
 
-    every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventTypes.PND_ALERTS_CHANGED) } just runs
+    every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.PND_ALERTS_CHANGED) } just runs
 
     hmppsDomainEventsListener.onDomainEvent(payload)
 
-    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventTypes.PND_ALERTS_CHANGED) }
+    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.PND_ALERTS_CHANGED) }
   }
 
   @ParameterizedTest
@@ -118,10 +118,10 @@ class HmppsDomainEventsListenerPNDAlertsTest {
     val payload = DomainEvents.generateDomainEvent(eventType, message)
     val hmppsDomainEvent = generateHmppsDomainEvent(eventType, hmppsMessage)
 
-    every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventTypes.PND_ALERTS_CHANGED) } just runs
+    every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.PND_ALERTS_CHANGED) } just runs
 
     hmppsDomainEventsListener.onDomainEvent(payload)
 
-    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventTypes.PND_ALERTS_CHANGED) }
+    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.PND_ALERTS_CHANGED) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListenerPNDAlertsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListenerPNDAlertsTest.kt
@@ -44,10 +44,12 @@ class HmppsDomainEventsListenerPNDAlertsTest {
     val hmppsDomainEvent = generateHmppsDomainEvent(eventType, hmppsMessage)
 
     every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.PND_ALERTS_CHANGED) } just runs
+    every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.ALERTS_CHANGED) } just runs
 
     hmppsDomainEventsListener.onDomainEvent(payload)
 
     verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.PND_ALERTS_CHANGED) }
+    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.ALERTS_CHANGED) }
   }
 
   @ParameterizedTest
@@ -69,10 +71,12 @@ class HmppsDomainEventsListenerPNDAlertsTest {
     val hmppsDomainEvent = generateHmppsDomainEvent(eventType, hmppsMessage)
 
     every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.PND_ALERTS_CHANGED) } just runs
+    every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.ALERTS_CHANGED) } just runs
 
     hmppsDomainEventsListener.onDomainEvent(payload)
 
     verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.PND_ALERTS_CHANGED) }
+    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.ALERTS_CHANGED) }
   }
 
   @ParameterizedTest
@@ -94,10 +98,12 @@ class HmppsDomainEventsListenerPNDAlertsTest {
     val hmppsDomainEvent = generateHmppsDomainEvent(eventType, hmppsMessage)
 
     every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.PND_ALERTS_CHANGED) } just runs
+    every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.ALERTS_CHANGED) } just runs
 
     hmppsDomainEventsListener.onDomainEvent(payload)
 
     verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.PND_ALERTS_CHANGED) }
+    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.ALERTS_CHANGED) }
   }
 
   @ParameterizedTest
@@ -119,9 +125,11 @@ class HmppsDomainEventsListenerPNDAlertsTest {
     val hmppsDomainEvent = generateHmppsDomainEvent(eventType, hmppsMessage)
 
     every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.PND_ALERTS_CHANGED) } just runs
+    every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.ALERTS_CHANGED) } just runs
 
     hmppsDomainEventsListener.onDomainEvent(payload)
 
     verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.PND_ALERTS_CHANGED) }
+    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.ALERTS_CHANGED) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListenerROSHTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListenerROSHTest.kt
@@ -11,7 +11,7 @@ import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents.ASSESSMENT_SUMMARY_PRODUCED
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents.generateHmppsDomainEvent
-import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventTypes
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventType
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.services.DeadLetterQueueService
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.services.HmppsDomainEventService
 
@@ -35,10 +35,10 @@ class HmppsDomainEventsListenerROSHTest {
     val payload = DomainEvents.generateDomainEvent(eventType, message)
     val hmppsDomainEvent = generateHmppsDomainEvent(eventType, hmppsMessage)
 
-    every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventTypes.RISK_OF_SERIOUS_HARM_CHANGED) } just runs
+    every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.RISK_OF_SERIOUS_HARM_CHANGED) } just runs
 
     hmppsDomainEventsListener.onDomainEvent(payload)
 
-    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventTypes.RISK_OF_SERIOUS_HARM_CHANGED) }
+    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.RISK_OF_SERIOUS_HARM_CHANGED) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListenerTest.kt
@@ -210,13 +210,13 @@ class HmppsDomainEventsListenerTest {
     val rawMessage = SqsNotificationGeneratingHelper(timestamp = currentTime)
       .generateRawHmppsDomainEventWithAlertCode(
         eventType = "person.alert.created",
-        alertCode = "HA"
+        alertCode = "HA",
       )
 
     val hmppsDomainEvent = SqsNotificationGeneratingHelper(currentTime)
       .createHmppsDomainEventWithAlertCode(
         eventType = "person.alert.created",
-        alertCode = "HA"
+        alertCode = "HA",
       )
 
     every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.ALERTS_CHANGED) } just runs
@@ -227,5 +227,4 @@ class HmppsDomainEventsListenerTest {
     verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.ALERTS_CHANGED) }
     verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.PND_ALERTS_CHANGED) }
   }
-
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListenerTest.kt
@@ -22,9 +22,10 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.D
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents.generateDomainEvent
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents.generateHmppsDomainEvent
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.SqsNotificationGeneratingHelper
-import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventTypes
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventType
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.services.DeadLetterQueueService
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.services.HmppsDomainEventService
+import java.io.File
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
@@ -47,11 +48,11 @@ class HmppsDomainEventsListenerTest {
     val rawMessage = SqsNotificationGeneratingHelper(timestamp = currentTime).generateRawHmppsDomainEventWithoutRegisterType("risk-assessment.scores.determined", messageEventType = "risk-assessment.scores.ogrs.determined")
     val hmppsDomainEvent = SqsNotificationGeneratingHelper(currentTime).createHmppsDomainEventWithoutRegisterType("risk-assessment.scores.ogrs.determined", attributeEventTypes = "risk-assessment.scores.determined")
 
-    every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventTypes.RISK_SCORE_CHANGED) } just runs
+    every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.RISK_SCORE_CHANGED) } just runs
 
     hmppsDomainEventsListener.onDomainEvent(rawMessage)
 
-    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventTypes.RISK_SCORE_CHANGED) }
+    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.RISK_SCORE_CHANGED) }
   }
 
   @ParameterizedTest
@@ -115,11 +116,11 @@ class HmppsDomainEventsListenerTest {
     val rawMessage = SqsNotificationGeneratingHelper(timestamp = currentTime).generateRawHmppsDomainEvent(eventType, registerTypeCode = registerTypeCode)
     val hmppsDomainEvent = SqsNotificationGeneratingHelper(currentTime).createHmppsDomainEvent(eventType, registerTypeCode = registerTypeCode)
 
-    every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventTypes.valueOf(integrationEvent)) } just runs
+    every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.valueOf(integrationEvent)) } just runs
 
     hmppsDomainEventsListener.onDomainEvent(rawMessage)
 
-    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventTypes.valueOf(integrationEvent)) }
+    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.valueOf(integrationEvent)) }
   }
 
   @ParameterizedTest
@@ -144,11 +145,11 @@ class HmppsDomainEventsListenerTest {
     val payload = generateDomainEvent(eventType, message)
     val hmppsDomainEvent = generateHmppsDomainEvent(eventType, hmppsMessage)
 
-    every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventTypes.PERSON_STATUS_CHANGED) } just runs
+    every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.PERSON_STATUS_CHANGED) } just runs
 
     hmppsDomainEventsListener.onDomainEvent(payload)
 
-    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventTypes.PERSON_STATUS_CHANGED) }
+    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.PERSON_STATUS_CHANGED) }
   }
 
   @Test
@@ -156,11 +157,11 @@ class HmppsDomainEventsListenerTest {
     val rawMessage = SqsNotificationGeneratingHelper(timestamp = currentTime).generateRawHmppsDomainEvent()
     val hmppsDomainEvent = SqsNotificationGeneratingHelper(currentTime).createHmppsDomainEvent()
 
-    every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventTypes.MAPPA_DETAIL_CHANGED) } just runs
+    every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.MAPPA_DETAIL_CHANGED) } just runs
 
     hmppsDomainEventsListener.onDomainEvent(rawMessage)
 
-    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventTypes.MAPPA_DETAIL_CHANGED) }
+    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.MAPPA_DETAIL_CHANGED) }
   }
 
   @Test
@@ -168,11 +169,11 @@ class HmppsDomainEventsListenerTest {
     val rawMessage = SqsNotificationGeneratingHelper(timestamp = currentTime).generateRawHmppsDomainEvent("probation-case.registration.updated")
     val hmppsDomainEvent = SqsNotificationGeneratingHelper(currentTime).createHmppsDomainEvent("probation-case.registration.updated")
 
-    every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventTypes.MAPPA_DETAIL_CHANGED) } just runs
+    every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.MAPPA_DETAIL_CHANGED) } just runs
 
     hmppsDomainEventsListener.onDomainEvent(rawMessage)
 
-    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventTypes.MAPPA_DETAIL_CHANGED) }
+    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.MAPPA_DETAIL_CHANGED) }
   }
 
   @Test
@@ -188,7 +189,6 @@ class HmppsDomainEventsListenerTest {
   fun `when an unexpected event type is received it should be sent to the dead letter queue`() {
     val unexpectedEventType = "unexpected.event.type"
     val rawMessage = SqsNotificationGeneratingHelper(timestamp = currentTime).generateRawHmppsDomainEvent(eventType = unexpectedEventType)
-    val hmppsDomainEvent = SqsNotificationGeneratingHelper(currentTime).createHmppsDomainEvent(eventType = unexpectedEventType)
 
     hmppsDomainEventsListener.onDomainEvent(rawMessage)
 
@@ -205,4 +205,18 @@ class HmppsDomainEventsListenerTest {
     verify { hmppsDomainEventService wasNot Called }
     verify { deadLetterQueueService wasNot Called }
   }
+
+  @Test
+  fun `when multiple event filters match, should execute hmppsDomainEventService for each`() {
+    val rawMessage = SqsNotificationGeneratingHelper(timestamp = currentTime).generateRawHmppsDomainEventWithoutRegisterType("risk-assessment.scores.determined", messageEventType = "risk-assessment.scores.ogrs.determined")
+    val hmppsDomainEvent = SqsNotificationGeneratingHelper(currentTime).createHmppsDomainEventWithoutRegisterType("risk-assessment.scores.ogrs.determined", attributeEventTypes = "risk-assessment.scores.determined")
+
+    every { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.RISK_SCORE_CHANGED) } just runs
+
+    hmppsDomainEventsListener.onDomainEvent(rawMessage)
+
+    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.RISK_SCORE_CHANGED) }
+
+  }
+
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListenerTest.kt
@@ -25,7 +25,6 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.S
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventType
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.services.DeadLetterQueueService
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.services.HmppsDomainEventService
-import java.io.File
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
@@ -216,7 +215,5 @@ class HmppsDomainEventsListenerTest {
     hmppsDomainEventsListener.onDomainEvent(rawMessage)
 
     verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.RISK_SCORE_CHANGED) }
-
   }
-
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/HmppsDomainEventsListenerTest.kt
@@ -226,5 +226,6 @@ class HmppsDomainEventsListenerTest {
 
     verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.ALERTS_CHANGED) }
     verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, IntegrationEventType.PND_ALERTS_CHANGED) }
+    verify(exactly = 2) { hmppsDomainEventService.execute(any(), any()) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/ResponsibleOfficerChangedEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/ResponsibleOfficerChangedEventTest.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.params.provider.ValueSource
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents.crn
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents.generateHmppsDomainEvent
-import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventTypes
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventType
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.services.DeadLetterQueueService
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.services.HmppsDomainEventService
 
@@ -40,7 +40,7 @@ class ResponsibleOfficerChangedEventTest {
     every {
       hmppsDomainEventService.execute(
         hmppsDomainEvent,
-        IntegrationEventTypes.RESPONSIBLE_OFFICER_CHANGED,
+        IntegrationEventType.RESPONSIBLE_OFFICER_CHANGED,
       )
     } just runs
 
@@ -49,7 +49,7 @@ class ResponsibleOfficerChangedEventTest {
     verify(exactly = 1) {
       hmppsDomainEventService.execute(
         hmppsDomainEvent,
-        IntegrationEventTypes.RESPONSIBLE_OFFICER_CHANGED,
+        IntegrationEventType.RESPONSIBLE_OFFICER_CHANGED,
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/EventNotifierServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/EventNotifierServiceTest.kt
@@ -13,7 +13,7 @@ import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.springframework.boot.test.autoconfigure.json.JsonTest
 import org.springframework.test.context.ActiveProfiles
-import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventTypes
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventType
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.repository.EventNotificationRepository
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.repository.model.data.EventNotification
 import java.time.LocalDateTime
@@ -44,7 +44,7 @@ class EventNotifierServiceTest {
 
   @Test
   fun `Event published for event notification in database`() {
-    val event = EventNotification(123, "hmppsId", IntegrationEventTypes.MAPPA_DETAIL_CHANGED, "mockUrl", currentTime)
+    val event = EventNotification(123, "hmppsId", IntegrationEventType.MAPPA_DETAIL_CHANGED, "mockUrl", currentTime)
     whenever(eventRepository.findAllWithLastModifiedDateTimeBefore(any())).thenReturn(listOf(event))
 
     emitter.sentNotifications()
@@ -59,7 +59,7 @@ class EventNotifierServiceTest {
 
   @Test
   fun `Remove event notification after event processed`() {
-    val event = EventNotification(123, "hmppsId", IntegrationEventTypes.MAPPA_DETAIL_CHANGED, "mockUrl", currentTime)
+    val event = EventNotification(123, "hmppsId", IntegrationEventType.MAPPA_DETAIL_CHANGED, "mockUrl", currentTime)
     whenever(eventRepository.findAllWithLastModifiedDateTimeBefore(any())).thenReturn(listOf(event))
 
     emitter.sentNotifications()
@@ -68,7 +68,7 @@ class EventNotifierServiceTest {
 
   @Test
   fun `on sns publish error do not delete event from db`() {
-    val event = EventNotification(123, "hmppsId", IntegrationEventTypes.MAPPA_DETAIL_CHANGED, "mockUrl", currentTime)
+    val event = EventNotification(123, "hmppsId", IntegrationEventType.MAPPA_DETAIL_CHANGED, "mockUrl", currentTime)
     whenever(eventRepository.findAllWithLastModifiedDateTimeBefore(any())).thenReturn(listOf(event))
     whenever(integrationEventTopicService.sendEvent(event)).thenThrow(RuntimeException("error"))
     emitter.sentNotifications()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/HmppsDomainEventServiceLicenceConditionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/HmppsDomainEventServiceLicenceConditionTest.kt
@@ -12,7 +12,7 @@ import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.gateway.ProbationIntegrationApiGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents.generateHmppsDomainEvent
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.PersonExists
-import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventTypes
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventType
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.repository.EventNotificationRepository
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.repository.model.data.EventNotification
 import java.time.LocalDateTime
@@ -55,12 +55,12 @@ class HmppsDomainEventServiceLicenceConditionTest {
     val hmppsMessage = message.replace("\\", "")
     val event = generateHmppsDomainEvent(eventType, hmppsMessage)
 
-    hmppsDomainEventService.execute(event, IntegrationEventTypes.LICENCE_CONDITION_CHANGED)
+    hmppsDomainEventService.execute(event, IntegrationEventType.LICENCE_CONDITION_CHANGED)
 
     verify(exactly = 1) {
       repo.save(
         EventNotification(
-          eventType = IntegrationEventTypes.LICENCE_CONDITION_CHANGED,
+          eventType = IntegrationEventType.LICENCE_CONDITION_CHANGED,
           hmppsId = "X777776",
           url = "$baseUrl/v1/persons/X777776/licences/conditions",
           lastModifiedDateTime = currentTime,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/HmppsDomainEventServiceROSHTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/HmppsDomainEventServiceROSHTest.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationevents.gateway.ProbationInte
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents.ASSESSMENT_SUMMARY_PRODUCED
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents.generateHmppsDomainEvent
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.PersonExists
-import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventTypes
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventType
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.repository.EventNotificationRepository
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.repository.model.data.EventNotification
 import java.time.LocalDateTime
@@ -46,12 +46,12 @@ class HmppsDomainEventServiceROSHTest {
     val hmppsMessage = message.replace("\\", "")
     val event = generateHmppsDomainEvent("assessment.summary.produced", hmppsMessage)
 
-    hmppsDomainEventService.execute(event, IntegrationEventTypes.RISK_OF_SERIOUS_HARM_CHANGED)
+    hmppsDomainEventService.execute(event, IntegrationEventType.RISK_OF_SERIOUS_HARM_CHANGED)
 
     verify(exactly = 1) {
       repo.save(
         EventNotification(
-          eventType = IntegrationEventTypes.RISK_OF_SERIOUS_HARM_CHANGED,
+          eventType = IntegrationEventType.RISK_OF_SERIOUS_HARM_CHANGED,
           hmppsId = crn,
           url = "$baseUrl/v1/persons/X777776/risks/serious-harm",
           lastModifiedDateTime = currentTime,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/IntegrationEventTopicServiceTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/IntegrationEventTopicServiceTests.kt
@@ -23,7 +23,7 @@ import software.amazon.awssdk.services.sns.model.PublishRequest
 import software.amazon.awssdk.services.sns.model.PublishResponse
 import software.amazon.awssdk.services.sns.model.SetSubscriptionAttributesRequest
 import software.amazon.awssdk.services.sns.model.Subscription
-import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventTypes
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventType
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.repository.model.data.EventNotification
 import uk.gov.justice.hmpps.sqs.HmppsQueue
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
@@ -52,7 +52,7 @@ class IntegrationEventTopicServiceTests(@Autowired private val objectMapper: Obj
 
   @Test
   fun `Publish Event `() {
-    val event = EventNotification(123, "hmppsId", IntegrationEventTypes.MAPPA_DETAIL_CHANGED, "mockUrl", currentTime)
+    val event = EventNotification(123, "hmppsId", IntegrationEventType.MAPPA_DETAIL_CHANGED, "mockUrl", currentTime)
 
     val response = PublishResponse
       .builder()


### PR DESCRIPTION
#### Context

- The `determineEventProcess` only allows an event to trigger a single Integration Event. We will want to be able to have a domain event trigger multiple Integration Events. For instance, we will probably want a generic “ALERTS_CHANGED” event for Kilco, but there is already a “PND_ALERTS_CHANGED” event. In the event that one of the PND alerts has changed, we need to trigger an integration event for each matching type.

#### Changes proposed in this PR

- Refactor function to trigger multiple integration events if there are multiple matches
- Changing enum name to not be plural
- ALERTS_CHANGED filter included as alerts endpoint is in list of allowed endpoints for Kilco
- Added a test to verify that when multiple integration event type filters match, multiple integration events are triggered.

