### PR TITLE
HMAI-549 Refactor stubApiResponse function to be a reusable class

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/mockServers/IntegrationApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/mockServers/IntegrationApiMockServer.kt
@@ -1,0 +1,46 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationevents.mockServers
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.matching
+import com.github.tomakehurst.wiremock.client.WireMock.notMatching
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.github.tomakehurst.wiremock.http.HttpHeader
+import com.github.tomakehurst.wiremock.http.HttpHeaders
+
+class IntegrationApiMockServer(httpPort: Int? = null, httpsPort: Int) : WireMockServer(
+  WireMockConfiguration.options().apply {
+    if (httpPort != null) port(httpPort)
+    httpsPort(httpsPort)
+  },
+) {
+  companion object {
+    fun create(httpsPort: Int, httpPort: Int? = null): IntegrationApiMockServer {
+      return IntegrationApiMockServer(httpPort, httpsPort)
+    }
+  }
+
+  fun stubApiResponse(apiKey: String, body: String) {
+    stubFor(
+      get("/v2/config/authorisation")
+        .withHeader("x-api-key", matching(apiKey))
+        .willReturn(
+          aResponse()
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withBody(body.trimIndent()),
+        ),
+    )
+
+    stubFor(
+      get("/v2/config/authorisation")
+        .withHeader("x-api-key", notMatching(apiKey))
+        .willReturn(
+          WireMock.aResponse()
+            .withStatus(401)
+            .withBody("Unauthorized"),
+        ),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/mockServers/IntegrationApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/mockServers/IntegrationApiMockServer.kt
@@ -10,15 +10,12 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.http.HttpHeader
 import com.github.tomakehurst.wiremock.http.HttpHeaders
 
-class IntegrationApiMockServer(httpPort: Int? = null, httpsPort: Int) : WireMockServer(
-  WireMockConfiguration.options().apply {
-    if (httpPort != null) port(httpPort)
-    httpsPort(httpsPort)
-  },
+class IntegrationApiMockServer(httpsPort: Int) : WireMockServer(
+  WireMockConfiguration.options().dynamicPort().httpsPort(httpsPort),
 ) {
   companion object {
-    fun create(httpsPort: Int, httpPort: Int? = null): IntegrationApiMockServer {
-      return IntegrationApiMockServer(httpPort, httpsPort)
+    fun create(httpsPort: Int): IntegrationApiMockServer {
+      return IntegrationApiMockServer(httpsPort)
     }
   }
 


### PR DESCRIPTION
#### Context

- Refactor stubApiResponse function to be a reusable class as there was a function in several test files

#### Changes proposed in this PR

- created a reusable class that takes a http or https port