### PR TITLE
Update name of slack alerts channel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,13 +13,14 @@ orbs:
                 sudo apt-get update
                 sudo apt-get -y install awscli
                 aws --version
+
 parameters:
   alerts-slack-channel:
     type: string
-    default: PIPELINE_SECURITY_SLACK_CHANNEL
+    default: hmpps-integration-api-alerts
   releases-slack-channel:
     type: string
-    default: SLACK_RELEASES_CHANNEL
+    default: hmpps-integration-api-alerts
 
 jobs:
   validate:


### PR DESCRIPTION
#### Context

- I can see that our security alerts have been failing to send to our Slack channel due to the name not being correct.

[CircleCI Job Failure](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-integration-events/886/workflows/4c770653-4239-4bd2-82ce-c002b64dee38/jobs/2433/parallel-runs/0/steps/0-112)

#### Changes proposed in this PR

- Update slack channels to match the value set in the `hmpps-integration-api` repo.