### PR TITLE
HMAI-554 - Fix netty vulnerability

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -10,3 +10,6 @@
 # Suppression for h2 2.1.214 password on command line vulnerability
 #   can be suppressed as we only run h2 locally and not on build environments
 CVE-2022-45868
+# Suppression for tomcat vulnerability affecting jsp compilation in the default servlet
+#   can be suppressed as we do not use the default servlet and haven't configured it for write either
+CVE-2024-50379

--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,5 @@ format:
 check:
 	./gradlew check
 
+analyse-dependencies:
+	./gradlew dependencyCheckAnalyze --info

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "7.1.2"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.1.0"
   kotlin("plugin.spring") version "2.0.21"
   kotlin("plugin.jpa") version "2.0.21"
   kotlin("plugin.lombok") version "2.0.21"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "6.1.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "7.1.2"
   kotlin("plugin.spring") version "2.0.21"
   kotlin("plugin.jpa") version "2.0.21"
   kotlin("plugin.lombok") version "2.0.21"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/config/HmppsSecretsManagerConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/config/HmppsSecretsManagerConfig.kt
@@ -25,54 +25,51 @@ class HmppsSecretsManagerConfig(
   }
 
   @Bean
-  fun secretsManagerClient(): SecretsManagerClient =
-    with(hmppsSecretManagerProperties) {
-      when (findProvider(provider)) {
-        Provider.AWS -> awsSecretsManagerClient()
-        Provider.LOCALSTACK -> localstackSecretsClient()
+  fun secretsManagerClient(): SecretsManagerClient = with(hmppsSecretManagerProperties) {
+    when (findProvider(provider)) {
+      Provider.AWS -> awsSecretsManagerClient()
+      Provider.LOCALSTACK -> localstackSecretsClient()
+    }
+  }
+
+  private fun awsSecretsManagerClient() = with(hmppsSecretManagerProperties) {
+    log.info("Creating AWS SecretsManagerClient with DefaultCredentialsProvider and region '$region'")
+
+    SecretsManagerClient.builder()
+      .credentialsProvider(DefaultCredentialsProvider.builder().build())
+      .region(Region.of(region))
+      .build()
+  }
+
+  private fun localstackSecretsClient(): SecretsManagerClient = with(hmppsSecretManagerProperties) {
+    log.info("Creating localstack SecretsManagerClient with StaticCredentialsProvider, localstackUrl '$localstackUrl' and region '$region'")
+
+    val client = SecretsManagerClient.builder()
+      .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("any", "any")))
+      .endpointOverride(java.net.URI.create(localstackUrl.replace("localhost", "127.0.0.1")))
+      .region(Region.of(region))
+      .build()
+
+    secrets.values.onEach {
+      try {
+        log.info("Checking for Secret '${it.secretId}'")
+
+        val describeSecretRequest = DescribeSecretRequest.builder()
+          .secretId(it.secretId)
+          .build()
+        client.describeSecret(describeSecretRequest)
+        log.info("Secret  '${it.secretId}' found")
+      } catch (e: ResourceNotFoundException) {
+        log.info("Creating Secret '${it.secretId}' as it was not found")
+
+        val bucketRequest = CreateSecretRequest.builder()
+          .name(it.secretId)
+          .build()
+
+        client.createSecret(bucketRequest)
       }
     }
 
-  private fun awsSecretsManagerClient() =
-    with(hmppsSecretManagerProperties) {
-      log.info("Creating AWS SecretsManagerClient with DefaultCredentialsProvider and region '$region'")
-
-      SecretsManagerClient.builder()
-        .credentialsProvider(DefaultCredentialsProvider.builder().build())
-        .region(Region.of(region))
-        .build()
-    }
-
-  private fun localstackSecretsClient(): SecretsManagerClient =
-    with(hmppsSecretManagerProperties) {
-      log.info("Creating localstack SecretsManagerClient with StaticCredentialsProvider, localstackUrl '$localstackUrl' and region '$region'")
-
-      val client = SecretsManagerClient.builder()
-        .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("any", "any")))
-        .endpointOverride(java.net.URI.create(localstackUrl.replace("localhost", "127.0.0.1")))
-        .region(Region.of(region))
-        .build()
-
-      secrets.values.onEach {
-        try {
-          log.info("Checking for Secret '${it.secretId}'")
-
-          val describeSecretRequest = DescribeSecretRequest.builder()
-            .secretId(it.secretId)
-            .build()
-          client.describeSecret(describeSecretRequest)
-          log.info("Secret  '${it.secretId}' found")
-        } catch (e: ResourceNotFoundException) {
-          log.info("Creating Secret '${it.secretId}' as it was not found")
-
-          val bucketRequest = CreateSecretRequest.builder()
-            .name(it.secretId)
-            .build()
-
-          client.createSecret(bucketRequest)
-        }
-      }
-
-      return client
-    }
+    return client
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/extensions/WebClientWrapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/extensions/WebClientWrapper.kt
@@ -39,17 +39,15 @@ class WebClientWrapper(
     upstreamApi: UpstreamApi,
     requestBody: Map<String, Any?>? = null,
     returnsEmpty: Boolean = false,
-  ): WebClientWrapperResponse<T> {
-    return try {
-      val responseData =
-        getResponseBodySpec(method, uri, headers, requestBody).retrieve()
-          .bodyToMono(T::class.java)
-          .block()!!
+  ): WebClientWrapperResponse<T> = try {
+    val responseData =
+      getResponseBodySpec(method, uri, headers, requestBody).retrieve()
+        .bodyToMono(T::class.java)
+        .block()!!
 
-      WebClientWrapperResponse.Success(responseData)
-    } catch (exception: WebClientResponseException) {
-      getErrorType(exception, upstreamApi, returnsEmpty)
-    }
+    WebClientWrapperResponse.Success(responseData)
+  } catch (exception: WebClientResponseException) {
+    getErrorType(exception, upstreamApi, returnsEmpty)
   }
 
   inline fun <reified T> requestList(
@@ -59,18 +57,16 @@ class WebClientWrapper(
     upstreamApi: UpstreamApi,
     requestBody: Map<String, Any?>? = null,
     returnsEmpty: Boolean = false,
-  ): WebClientWrapperResponse<List<T>> {
-    return try {
-      val responseData =
-        getResponseBodySpec(method, uri, headers, requestBody).retrieve()
-          .bodyToFlux(T::class.java)
-          .collectList()
-          .block() as List<T>
+  ): WebClientWrapperResponse<List<T>> = try {
+    val responseData =
+      getResponseBodySpec(method, uri, headers, requestBody).retrieve()
+        .bodyToFlux(T::class.java)
+        .collectList()
+        .block() as List<T>
 
-      WebClientWrapperResponse.Success(responseData)
-    } catch (exception: WebClientResponseException) {
-      getErrorType(exception, upstreamApi, returnsEmpty)
-    }
+    WebClientWrapperResponse.Success(responseData)
+  } catch (exception: WebClientResponseException) {
+    getErrorType(exception, upstreamApi, returnsEmpty)
   }
 
   fun getResponseBodySpec(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/gateway/HmppsAuthGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/gateway/HmppsAuthGateway.kt
@@ -28,24 +28,22 @@ class HmppsAuthGateway(
     }
   }
 
-  fun getClientToken(service: String): String {
-    return try {
-      val response =
-        webClient
-          .post()
-          .uri("/auth/oauth/token?grant_type=client_credentials")
-          .header("Authorization", Credentials.toBasicAuth(username, password))
-          .retrieve()
-          .bodyToMono(String::class.java)
-          .block()
+  fun getClientToken(service: String): String = try {
+    val response =
+      webClient
+        .post()
+        .uri("/auth/oauth/token?grant_type=client_credentials")
+        .header("Authorization", Credentials.toBasicAuth(username, password))
+        .retrieve()
+        .bodyToMono(String::class.java)
+        .block()
 
-      JSONParser(response).parseObject()["access_token"].toString()
-    } catch (exception: WebClientRequestException) {
-      throw AuthenticationFailedException("Connection to ${exception.uri.authority} failed for $service.")
-    } catch (exception: WebClientResponseException.ServiceUnavailable) {
-      throw AuthenticationFailedException("${exception.request?.uri?.authority} is unavailable for $service.")
-    } catch (exception: WebClientResponseException.Unauthorized) {
-      throw AuthenticationFailedException("Invalid credentials used for $service.")
-    }
+    JSONParser(response).parseObject()["access_token"].toString()
+  } catch (exception: WebClientRequestException) {
+    throw AuthenticationFailedException("Connection to ${exception.uri.authority} failed for $service.")
+  } catch (exception: WebClientResponseException.ServiceUnavailable) {
+    throw AuthenticationFailedException("${exception.request?.uri?.authority} is unavailable for $service.")
+  } catch (exception: WebClientResponseException.Unauthorized) {
+    throw AuthenticationFailedException("Invalid credentials used for $service.")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/gateway/IntegrationApiGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/gateway/IntegrationApiGateway.kt
@@ -54,12 +54,10 @@ class IntegrationApiGateway(
       .build()
   }
 
-  fun getApiAuthorizationConfig(): Map<String, ConfigAuthorisation> {
-    return webClient.method(HttpMethod.GET)
-      .uri("v2/config/authorisation")
-      .retrieve()
-      .bodyToMono(object : ParameterizedTypeReference<Map<String, ConfigAuthorisation>>() {})
-      .block()!!
-      .mapKeys { (key, _) -> key.replace(".", "-") }
-  }
+  fun getApiAuthorizationConfig(): Map<String, ConfigAuthorisation> = webClient.method(HttpMethod.GET)
+    .uri("v2/config/authorisation")
+    .retrieve()
+    .bodyToMono(object : ParameterizedTypeReference<Map<String, ConfigAuthorisation>>() {})
+    .block()!!
+    .mapKeys { (key, _) -> key.replace(".", "-") }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/enums/IntegrationEventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/enums/IntegrationEventType.kt
@@ -156,10 +156,9 @@ enum class IntegrationEventType(val value: String, private val pathTemplate: Str
   fun path(hmppsId: String) = pathTemplate.replace("{hmppsId}", hmppsId)
 
   companion object {
-    fun from(eventType: IntegrationEventType): IntegrationEventType? =
-      IntegrationEventType.entries.firstOrNull {
-        it.value == eventType.value
-      }
+    fun from(eventType: IntegrationEventType): IntegrationEventType? = IntegrationEventType.entries.firstOrNull {
+      it.value == eventType.value
+    }
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/registration/HmppsDomainEventMessage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/registration/HmppsDomainEventMessage.kt
@@ -16,12 +16,8 @@ data class HmppsDomainEventMessage(
 data class PersonReference(
   @JsonProperty("identifiers") val identifiers: List<Identifier>,
 ) {
-  fun findCrnIdentifier(): String? {
-    return this.identifiers.firstOrNull { it.type == "CRN" }?.value
-  }
-  fun findNomsIdentifier(): String? {
-    return this.identifiers.firstOrNull { it.type == "nomsNumber" || it.type == "NOMS" }?.value
-  }
+  fun findCrnIdentifier(): String? = this.identifiers.firstOrNull { it.type == "CRN" }?.value
+  fun findNomsIdentifier(): String? = this.identifiers.firstOrNull { it.type == "nomsNumber" || it.type == "NOMS" }?.value
 }
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/helpers/DomainEvents.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/helpers/DomainEvents.kt
@@ -54,11 +54,10 @@ object DomainEvents {
     }    
   """.trimIndent()
 
-  fun generateHmppsDomainEvent(eventType: String, message: String) =
-    HmppsDomainEvent(
-      type = "Notification",
-      message = message,
-      messageId = "d4419bdd-2079-598c-b608-c4f2ddb1bcd1",
-      messageAttributes = DomainEventMessageAttributes(EventType(eventType)),
-    )
+  fun generateHmppsDomainEvent(eventType: String, message: String) = HmppsDomainEvent(
+    type = "Notification",
+    message = message,
+    messageId = "d4419bdd-2079-598c-b608-c4f2ddb1bcd1",
+    messageAttributes = DomainEventMessageAttributes(EventType(eventType)),
+  )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/services/EventSubscriberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/services/EventSubscriberTest.kt
@@ -29,7 +29,7 @@ import java.util.concurrent.TimeUnit
 @ExtendWith(SpringExtension::class)
 @SpringBootTest
 @ActiveProfiles("test")
-class EventSubscriberTest() {
+class EventSubscriberTest {
   @Autowired
   lateinit var hmppsQueueService: HmppsQueueService
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/services/IntegrationEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/services/IntegrationEventTest.kt
@@ -72,12 +72,10 @@ class IntegrationEventTest {
       .map(SQSMessage::Message)
       .toList()
   }
-  private fun toSQSMessage(message: String): SQSMessage {
-    return try {
-      objectMapper.readValue(message, SQSMessage::class.java)
-    } catch (e: JsonProcessingException) {
-      throw AssertionFailedError(String.format("Message %s is not parseable", message))
-    }
+  private fun toSQSMessage(message: String): SQSMessage = try {
+    objectMapper.readValue(message, SQSMessage::class.java)
+  } catch (e: JsonProcessingException) {
+    throw AssertionFailedError(String.format("Message %s is not parseable", message))
   }
   fun getNumberOfMessagesCurrentlyOnIntegrationEventTestQueue(): Int = integrationEventTestQueueSqsClient.countAllMessagesOnQueue(integrationEventTestQueueUrl).get()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/mockServers/IntegrationApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/mockServers/IntegrationApiMockServer.kt
@@ -10,13 +10,12 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.http.HttpHeader
 import com.github.tomakehurst.wiremock.http.HttpHeaders
 
-class IntegrationApiMockServer(httpsPort: Int) : WireMockServer(
-  WireMockConfiguration.options().dynamicPort().httpsPort(httpsPort),
-) {
+class IntegrationApiMockServer(httpsPort: Int) :
+  WireMockServer(
+    WireMockConfiguration.options().dynamicPort().httpsPort(httpsPort),
+  ) {
   companion object {
-    fun create(httpsPort: Int): IntegrationApiMockServer {
-      return IntegrationApiMockServer(httpsPort)
-    }
+    fun create(httpsPort: Int): IntegrationApiMockServer = IntegrationApiMockServer(httpsPort)
   }
 
   fun stubApiResponse(apiKey: String, body: String) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/resources/EventAPIMockMvc.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/resources/EventAPIMockMvc.kt
@@ -23,7 +23,5 @@ class EventAPIMockMvc(
     return mockMvc.perform(MockMvcRequestBuilders.get(path).header("subject-distinguished-name", subjectDistinguishedName)).andReturn()
   }
 
-  fun performUnAuthorised(path: String): MvcResult {
-    return mockMvc.perform(MockMvcRequestBuilders.get(path)).andReturn()
-  }
+  fun performUnAuthorised(path: String): MvcResult = mockMvc.perform(MockMvcRequestBuilders.get(path)).andReturn()
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/resources/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/resources/IntegrationTestBase.kt
@@ -8,7 +8,7 @@ import org.springframework.test.web.reactive.server.WebTestClient
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ActiveProfiles("test")
-abstract class IntegrationTestBase() {
+abstract class IntegrationTestBase {
 
   @Suppress("SpringJavaInjectionPointsAutowiringInspection")
   @Autowired

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/resources/SqsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/resources/SqsIntegrationTestBase.kt
@@ -62,18 +62,14 @@ abstract class SqsIntegrationTestBase {
       .toList()
   }
 
-  protected fun geMessagesCurrentlyOnDomainEventsDeadLetterQueue(): ReceiveMessageResponse {
-    return domainEventsDeadLetterSqsClient.receiveMessage(
-      ReceiveMessageRequest.builder().queueUrl(domainEventsDeadLetterSqsUrl).messageAttributeNames("All").build(),
-    ).get()
-  }
+  protected fun geMessagesCurrentlyOnDomainEventsDeadLetterQueue(): ReceiveMessageResponse = domainEventsDeadLetterSqsClient.receiveMessage(
+    ReceiveMessageRequest.builder().queueUrl(domainEventsDeadLetterSqsUrl).messageAttributeNames("All").build(),
+  ).get()
 
-  internal fun toSQSMessage(message: String): IntegrationEventTest.SQSMessage {
-    return try {
-      objectMapper.readValue(message, IntegrationEventTest.SQSMessage::class.java)
-    } catch (e: JsonProcessingException) {
-      throw AssertionFailedError(String.format("Message %s is not parseable", message))
-    }
+  internal fun toSQSMessage(message: String): IntegrationEventTest.SQSMessage = try {
+    objectMapper.readValue(message, IntegrationEventTest.SQSMessage::class.java)
+  } catch (e: JsonProcessingException) {
+    throw AssertionFailedError(String.format("Message %s is not parseable", message))
   }
 
   protected fun sendDomainSqsMessage(rawMessage: String) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/resources/wiremock/HmppsAuthExtension.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/resources/wiremock/HmppsAuthExtension.kt
@@ -5,7 +5,10 @@ import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 
-class HmppsAuthExtension : BeforeAllCallback, AfterAllCallback, BeforeEachCallback {
+class HmppsAuthExtension :
+  BeforeAllCallback,
+  AfterAllCallback,
+  BeforeEachCallback {
   override fun afterAll(context: ExtensionContext): Unit = server.stop()
 
   override fun beforeAll(context: ExtensionContext) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/resources/wiremock/ProbationIntegrationApiExtension.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/resources/wiremock/ProbationIntegrationApiExtension.kt
@@ -5,7 +5,10 @@ import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 
-class ProbationIntegrationApiExtension : BeforeAllCallback, AfterAllCallback, BeforeEachCallback {
+class ProbationIntegrationApiExtension :
+  BeforeAllCallback,
+  AfterAllCallback,
+  BeforeEachCallback {
   override fun afterAll(context: ExtensionContext): Unit = server.stop()
   override fun beforeAll(context: ExtensionContext): Unit = server.start()
   override fun beforeEach(context: ExtensionContext): Unit = server.resetRequests()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/IntegrationEventTopicServiceTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/IntegrationEventTopicServiceTests.kt
@@ -98,7 +98,7 @@ class IntegrationEventTopicServiceTests(@Autowired private val objectMapper: Obj
   }
 
   @Test
-  fun`Get subscription arn for given queue name`() {
+  fun `Get subscription arn for given queue name`() {
     val mockSubs = listOf(Subscription.builder().protocol("sqs").endpoint("mockARN").subscriptionArn("mockSubscriptionArn").build())
 
     whenever(hmppsEventSnsClient.listSubscriptionsByTopic(any<ListSubscriptionsByTopicRequest>()))


### PR DESCRIPTION
### Context

- CVE-2025-24970 was found in our [hmpps/trivy_latest_scan](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-integration-events/886/workflows/4c770653-4239-4bd2-82ce-c002b64dee38/jobs/2434) job

### Changes proposed in this PR

- Bump `uk.gov.justice.hmpps.gradle-spring-boot`, which contains the transitive `netty` dependency, to version `8.1.0` to match `hmpps-integration-api`.
- Fixed new lint errors found post update
- Add `analyse-dependencies` command to Makefile
- Running `analyse-dependencies` locally also updated our `.trivyignore` file