### PR TITLE
Fix trivy scan slack alerts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,10 @@ workflows:
   version: 2
   build-test-and-deploy:
     jobs:
+      - hmpps/trivy_latest_scan:
+          slack_channel: << pipeline.parameters.alerts-slack-channel >>
+          context:
+            - hmpps-common-vars
       - validate:
           filters:
             tags:


### PR DESCRIPTION
#### Context

- Slack alerts seem to be failing due to unescaped characters in error message. See [job](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-integration-events/894/workflows/33c46c06-33f7-4dda-a80e-4a3bce60e205/jobs/2456)

#### Changes proposed in this PR

-