### PR TITLE
HMAI-563 - Replace hardcoded localstack secrets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,15 +21,6 @@ parameters:
   releases-slack-channel:
     type: string
     default: hmpps-integration-api-alerts
-  postgres_name:
-    type: string
-    default: "${DB_NAME}"
-  postgres_user:
-    type: string
-    default: "${DB_USER}"
-  postgres_password:
-    type: string
-    default: "${DB_PASS}"
 
 jobs:
   validate:
@@ -39,10 +30,14 @@ jobs:
       localstack_tag: "3"
       services: "sqs,sns,s3,secretsmanager"
       postgres_tag: "15"
-      postgres_db: << pipeline.parameters.postgres_name >>
-      postgres_username: << pipeline.parameters.postgres_user >>
-      postgres_password: << pipeline.parameters.postgres_password >>
+#      postgres_db: << pipeline.parameters.postgres_name >>
+#      postgres_username: << pipeline.parameters.postgres_user >>
+#      postgres_password: << pipeline.parameters.postgres_password >>
       resource_class: medium+
+    environment:
+      POSTGRES_NAME: "$DB_NAME"
+      POSTGRES_USER: "$DB_USER"
+      POSTGRES_PASSWORD: "$DB_PASSW"
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,51 +22,22 @@ parameters:
     type: string
     default: hmpps-integration-api-alerts
 
-    parameters:
-      resource_class:
-        default: medium
-        type: string
-      jdk_tag:
-        type: string
-      localstack_tag:
-        type: string
-      localstack_type:
-        default: "localstack"
-        type: string
-      services:
-        default: "sqs,sns"
-        type: string
-      postgres_tag:
-        type: string
-      postgres_password:
-        default: "dev"
-        type: string
-      postgres_username:
-        default: "root"
-        type: string
-      postgres_port:
-        default: 5432
-        type: integer
-      java_options:
-        default: -Xmx512m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process -Dorg.gradle.workers.max=1
-        type: string
-
 jobs:
   validate:
-#    executor:
-#      name: hmpps/java_localstack_postgres_with_db_name
-#      jdk_tag: "21.0"
-#      localstack_tag: "3"
-#      services: "sqs,sns,s3,secretsmanager"
-#      postgres_tag: "15"
-##      postgres_db: << pipeline.parameters.postgres_name >>
-##      postgres_username: << pipeline.parameters.postgres_user >>
-##      postgres_password: << pipeline.parameters.postgres_password >>
-#      resource_class: medium+
-#    environment:
-#      POSTGRES_NAME: "$DB_NAME"
-#      POSTGRES_USER: "$DB_USER"
-#      POSTGRES_PASSWORD: "$DB_PASSW"
+    #    executor:
+    #      name: hmpps/java_localstack_postgres_with_db_name
+    #      jdk_tag: "21.0"
+    #      localstack_tag: "3"
+    #      services: "sqs,sns,s3,secretsmanager"
+    #      postgres_tag: "15"
+    ##      postgres_db: << pipeline.parameters.postgres_name >>
+    ##      postgres_username: << pipeline.parameters.postgres_user >>
+    ##      postgres_password: << pipeline.parameters.postgres_password >>
+    #      resource_class: medium+
+    #    environment:
+    #      POSTGRES_NAME: "$DB_NAME"
+    #      POSTGRES_USER: "$DB_USER"
+    #      POSTGRES_PASSWORD: "$DB_PASSW"
     docker:
       - image: cimg/openjdk:21.0
       - image: localstack/localstack:3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,9 @@ jobs:
       localstack_tag: "3"
       services: "sqs,sns,s3,secretsmanager"
       postgres_tag: "15"
+      postgres_db: $POSTGRES_DB
+      postgres_username: $POSTGRES_USER
+      postgres_password: $POSTGRES_PASSWORD
       resource_class: medium+
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       services: "sqs,sns,s3,secretsmanager"
       postgres_tag: "15"
       postgres_db: POSTGRES_DB
-      postgres_username: POSTGRES_USER
+      postgres_username: "postgres"
       postgres_password: POSTGRES_PASSWORD
       resource_class: medium+
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,12 +48,12 @@ jobs:
           - DOCKER_HOST=unix:///var/run/docker.sock
           - AWS_EXECUTION_ENV=True
           - PERSISTENCE=1
-      - image: postgres:15
-        environment:
-          POSTGRES_DB: "$DB_NAME"
-          POSTGRES_USER: "$DB_USER"
-          POSTGRES_PASSWORD: "$DB_PASS"
-          PGPORT: 5432
+#      - image: postgres:15
+#        environment:
+#          POSTGRES_DB: "$DB_NAME"
+#          POSTGRES_USER: "$DB_USER"
+#          POSTGRES_PASSWORD: "$DB_PASS"
+#          PGPORT: 5432
     environment:
       _JAVA_OPTIONS: -Xmx512m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process -Dorg.gradle.workers.max=1
     working_directory: ~/app
@@ -64,6 +64,22 @@ jobs:
           keys:
             - gradle-{{ checksum "build.gradle.kts" }}
             - gradle-
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: Create .env file for database
+          command: |
+            # Create a file for Postgres environment variables
+            echo "POSTGRES_DB=$DB_NAME" > ./.temp-db.env
+            echo "POSTGRES_USER=$DB_USER" >> ./.temp-db.env
+            echo "POSTGRES_PASSWORD=$DB_PASS" >> ./.temp-db.env # Securely reading the secret
+            echo "PGPORT=5432" >> ./.temp-db.env
+            echo "--- ./.temp-db.env contents (for debug) ---"
+            cat ./.temp-db.env
+      - run:
+          name: Start PostgreSQL Docker Container
+          command: |
+            docker run -d --name my-postgres --env-file ./.temp-db.env -p 5432:5432 postgres:15
       - hmpps/wait_till_ready_postgres
       - service-adapter/aws_cli_install
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,9 +30,9 @@ jobs:
       localstack_tag: "3"
       services: "sqs,sns,s3,secretsmanager"
       postgres_tag: "15"
-      postgres_db: "$DB_NAME"
-      postgres_username: "$DB_USER"
-      postgres_password: "$DB_PASS"
+      postgres_db: $DB_NAME
+      postgres_username: $DB_USER
+      postgres_password: $DB_PASS
       resource_class: medium+
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
           name: Start services with Docker Compose
           command: |
             docker-compose up -d --wait
-      - hmpps/wait_till_ready_postgres
+#      - hmpps/wait_till_ready_postgres
       - service-adapter/aws_cli_install
       - run:
           name: setup local stack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,15 @@ parameters:
   releases-slack-channel:
     type: string
     default: hmpps-integration-api-alerts
+  postgres_name:
+    type: string
+    default: "${DB_NAME}"
+  postgres_user:
+    type: string
+    default: "${DB_USER}"
+  postgres_password:
+    type: string
+    default: "${DB_PASS}"
 
 jobs:
   validate:
@@ -30,23 +39,12 @@ jobs:
       localstack_tag: "3"
       services: "sqs,sns,s3,secretsmanager"
       postgres_tag: "15"
-      postgres_db: POSTGRES_DB
-      postgres_username: "postgres"
-      postgres_password: POSTGRES_PASSWORD
+      postgres_db: << pipeline.parameters.postgres_name >>
+      postgres_username: << pipeline.parameters.postgres_user >>
+      postgres_password: << pipeline.parameters.postgres_password >>
       resource_class: medium+
     steps:
       - checkout
-      - run:
-          name: Set Database Credentials
-          command: |
-            echo "Making environment variables available for application."  
-            export POSTGRES_DB="$POSTGRES_DB"  
-            export POSTGRES_USER="$POSTGRES_USER"  
-            export POSTGRES_PASSWORD="$POSTGRES_PASSWORD"
-          environment:
-            POSTGRES_DB: "$DB_NAME"
-            POSTGRES_USER: "$DB_USER"
-            POSTGRES_PASSWORD: "$DB_PASS"
       - restore_cache:
           keys:
             - gradle-{{ checksum "build.gradle.kts" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
       aws_cli_install:
         steps:
           - run:
-              name: Install aws cli
+              name: Install AWS CLI
               command: |
                 sudo apt-get update
                 sudo apt-get -y install awscli
@@ -45,7 +45,14 @@ jobs:
             # Postgres
             echo "POSTGRES_DB=$DB_NAME" > .env
             echo "POSTGRES_USER=$DB_USER" >> .env
-            echo "POSTGRES_PASSWORD=$DB_PASS" >> .env # Securely reading the secret
+            echo "POSTGRES_PASSWORD=$DB_PASS" >> .env
+            
+            # Localstack
+            echo "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" > .env
+            echo "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" > .env
+            echo "TEST_CLIENT_SECRET_NAME=$TEST_CLIENT_SECRET_NAME" > .env
+            echo "TEST_CLIENT_SECRET_VALUE=$TEST_CLIENT_SECRET_VALUE" > .env
+            
             echo "--- .env contents (for debug) ---"
             cat .env
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,9 +30,9 @@ jobs:
       localstack_tag: "3"
       services: "sqs,sns,s3,secretsmanager"
       postgres_tag: "15"
-      postgres_db: $POSTGRES_DB
-      postgres_username: $POSTGRES_USER
-      postgres_password: $POSTGRES_PASSWORD
+      postgres_db: POSTGRES_DB
+      postgres_username: POSTGRES_USER
+      postgres_password: POSTGRES_PASSWORD
       resource_class: medium+
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - run:
           name: Start services
           command: |
-            make serve
+            docker-compose up --build -d --wait
       - service-adapter/aws_cli_install
       - run:
           name: Run Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,14 +40,14 @@ jobs:
     #      POSTGRES_PASSWORD: "$DB_PASSW"
     docker:
       - image: cimg/openjdk:21.0
-      - image: localstack/localstack:3
-        environment:
-          - SERVICES="sqs,sns,s3,secretsmanager"
-          - ES_PORT_EXTERNAL=4571
-          - DEBUG=${DEBUG- }
-          - DOCKER_HOST=unix:///var/run/docker.sock
-          - AWS_EXECUTION_ENV=True
-          - PERSISTENCE=1
+#      - image: localstack/localstack:3
+#        environment:
+#          - SERVICES="sqs,sns,s3,secretsmanager"
+#          - ES_PORT_EXTERNAL=4571
+#          - DEBUG=${DEBUG- }
+#          - DOCKER_HOST=unix:///var/run/docker.sock
+#          - AWS_EXECUTION_ENV=True
+#          - PERSISTENCE=1
 #      - image: postgres:15
 #        environment:
 #          POSTGRES_DB: "$DB_NAME"
@@ -67,19 +67,18 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          name: Create .env file for database
+          name: Create .env file for docker compose
           command: |
-            # Create a file for Postgres environment variables
-            echo "POSTGRES_DB=$DB_NAME" > ./.temp-db.env
-            echo "POSTGRES_USER=$DB_USER" >> ./.temp-db.env
-            echo "POSTGRES_PASSWORD=$DB_PASS" >> ./.temp-db.env # Securely reading the secret
-            echo "PGPORT=5432" >> ./.temp-db.env
-            echo "--- ./.temp-db.env contents (for debug) ---"
-            cat ./.temp-db.env
+            # Postgres
+            echo "POSTGRES_DB=$DB_NAME" > .env
+            echo "POSTGRES_USER=$DB_USER" >> .env
+            echo "POSTGRES_PASSWORD=$DB_PASS" >> .env # Securely reading the secret
+            echo "--- .env contents (for debug) ---"
+            cat .env
       - run:
-          name: Start PostgreSQL Docker Container
+          name: Start services with Docker Compose
           command: |
-            docker run -d --name my-postgres --env-file ./.temp-db.env -p 5432:5432 postgres:15
+            docker-compose up -d --wait
       - hmpps/wait_till_ready_postgres
       - service-adapter/aws_cli_install
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,9 +52,6 @@ jobs:
             echo "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" > .env
             echo "TEST_CLIENT_SECRET_NAME=$TEST_CLIENT_SECRET_NAME" > .env
             echo "TEST_CLIENT_SECRET_VALUE=$TEST_CLIENT_SECRET_VALUE" > .env
-            
-            echo "--- .env contents (for debug) ---"
-            cat .env
       - run:
           name: Start services with Docker Compose
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,11 @@ jobs:
       - checkout
       - run:
           name: Set Database Credentials
+          command: |
+            echo "Making environment variables available for application."  
+            export POSTGRES_DB="$POSTGRES_DB"  
+            export POSTGRES_USER="$POSTGRES_USER"  
+            export POSTGRES_PASSWORD="$POSTGRES_PASSWORD"
           environment:
             POSTGRES_DB: "$DB_NAME"
             POSTGRES_USER: "$DB_USER"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,48 +24,21 @@ parameters:
 
 jobs:
   validate:
-    #    executor:
-    #      name: hmpps/java_localstack_postgres_with_db_name
-    #      jdk_tag: "21.0"
-    #      localstack_tag: "3"
-    #      services: "sqs,sns,s3,secretsmanager"
-    #      postgres_tag: "15"
-    ##      postgres_db: << pipeline.parameters.postgres_name >>
-    ##      postgres_username: << pipeline.parameters.postgres_user >>
-    ##      postgres_password: << pipeline.parameters.postgres_password >>
-    #      resource_class: medium+
-    #    environment:
-    #      POSTGRES_NAME: "$DB_NAME"
-    #      POSTGRES_USER: "$DB_USER"
-    #      POSTGRES_PASSWORD: "$DB_PASSW"
-    docker:
-      - image: cimg/openjdk:21.0
-#      - image: localstack/localstack:3
-#        environment:
-#          - SERVICES="sqs,sns,s3,secretsmanager"
-#          - ES_PORT_EXTERNAL=4571
-#          - DEBUG=${DEBUG- }
-#          - DOCKER_HOST=unix:///var/run/docker.sock
-#          - AWS_EXECUTION_ENV=True
-#          - PERSISTENCE=1
-#      - image: postgres:15
-#        environment:
-#          POSTGRES_DB: "$DB_NAME"
-#          POSTGRES_USER: "$DB_USER"
-#          POSTGRES_PASSWORD: "$DB_PASS"
-#          PGPORT: 5432
-    environment:
-      _JAVA_OPTIONS: -Xmx512m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process -Dorg.gradle.workers.max=1
-    working_directory: ~/app
-    resource_class: medium+
+    machine:
+      image: ubuntu-2204:2022.10.2
     steps:
       - checkout
       - restore_cache:
           keys:
             - gradle-{{ checksum "build.gradle.kts" }}
             - gradle-
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - run:
+          name: Install OpenJDK 21
+          command: |
+            sudo apt-get update && sudo apt-get install openjdk-21-jdk
+            sudo update-alternatives --set java /usr/lib/jvm/java-21-openjdk-amd64/bin/java
+            sudo update-alternatives --set javac /usr/lib/jvm/java-21-openjdk-amd64/bin/javac
+            java -version
       - run:
           name: Create .env file for docker compose
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,10 +50,10 @@ jobs:
           - PERSISTENCE=1
       - image: postgres:15
         environment:
-          - POSTGRES_DB=${DB_NAME}
-          - POSTGRES_USER=${DB_USER}
-          - POSTGRES_PASSWORD=${DB_PASS}
-          - PGPORT=5432
+          POSTGRES_DB: $DB_NAME
+          POSTGRES_USER: $DB_USER
+          POSTGRES_PASSWORD: $DB_PASS
+          PGPORT: 5432
     environment:
       _JAVA_OPTIONS: -Xmx512m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process -Dorg.gradle.workers.max=1
     working_directory: ~/app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,9 +40,9 @@ jobs:
             sudo update-alternatives --set javac /usr/lib/jvm/java-21-openjdk-amd64/bin/javac
             java -version
       - run:
-          name: Start services with Docker Compose
+          name: Start services
           command: |
-            docker-compose up -d --wait
+            make serve
       - service-adapter/aws_cli_install
       - run:
           name: Run Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,19 +40,6 @@ jobs:
             sudo update-alternatives --set javac /usr/lib/jvm/java-21-openjdk-amd64/bin/javac
             java -version
       - run:
-          name: Create .env file
-          command: |
-            # Postgres
-            echo "POSTGRES_DB=$DB_NAME" > .env
-            echo "POSTGRES_USER=$DB_USER" >> .env
-            echo "POSTGRES_PASSWORD=$DB_PASS" >> .env
-            
-            # Localstack
-            echo "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" > .env
-            echo "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" > .env
-            echo "TEST_CLIENT_SECRET_NAME=$TEST_CLIENT_SECRET_NAME" > .env
-            echo "TEST_CLIENT_SECRET_VALUE=$TEST_CLIENT_SECRET_VALUE" > .env
-      - run:
           name: Start services with Docker Compose
           command: |
             docker-compose up -d --wait

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,9 +30,9 @@ jobs:
       localstack_tag: "3"
       services: "sqs,sns,s3,secretsmanager"
       postgres_tag: "15"
-      postgres_db: $DB_NAME
-      postgres_username: $DB_USER
-      postgres_password: $DB_PASS
+      postgres_db: "'$DB_NAME'"
+      postgres_username: "'$DB_USER'"
+      postgres_password: "'$DB_PASS'"
       resource_class: medium+
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,9 +30,9 @@ jobs:
       localstack_tag: "3"
       services: "sqs,sns,s3,secretsmanager"
       postgres_tag: "15"
-      postgres_db: "event_store"
-      postgres_username: "postgres"
-      postgres_password: "pa55word"
+      postgres_db: "$DB_NAME"
+      postgres_username: "$DB_USER"
+      postgres_password: "$DB_PASS"
       resource_class: medium+
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,9 +50,9 @@ jobs:
           - PERSISTENCE=1
       - image: postgres:15
         environment:
-          POSTGRES_DB: $DB_NAME
-          POSTGRES_USER: $DB_USER
-          POSTGRES_PASSWORD: $DB_PASS
+          POSTGRES_DB: "$DB_NAME"
+          POSTGRES_USER: "$DB_USER"
+          POSTGRES_PASSWORD: "$DB_PASS"
           PGPORT: 5432
     environment:
       _JAVA_OPTIONS: -Xmx512m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process -Dorg.gradle.workers.max=1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,12 +30,15 @@ jobs:
       localstack_tag: "3"
       services: "sqs,sns,s3,secretsmanager"
       postgres_tag: "15"
-      postgres_db: "'$DB_NAME'"
-      postgres_username: "'$DB_USER'"
-      postgres_password: "'$DB_PASS'"
       resource_class: medium+
     steps:
       - checkout
+      - run:
+          name: Set Database Credentials
+          environment:
+            POSTGRES_DB: "$DB_NAME"
+            POSTGRES_USER: "$DB_USER"
+            POSTGRES_PASSWORD: "$DB_PASS"
       - restore_cache:
           keys:
             - gradle-{{ checksum "build.gradle.kts" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
             sudo update-alternatives --set javac /usr/lib/jvm/java-21-openjdk-amd64/bin/javac
             java -version
       - run:
-          name: Create .env file for docker compose
+          name: Create .env file
           command: |
             # Postgres
             echo "POSTGRES_DB=$DB_NAME" > .env
@@ -52,14 +52,9 @@ jobs:
           name: Start services with Docker Compose
           command: |
             docker-compose up -d --wait
-#      - hmpps/wait_till_ready_postgres
       - service-adapter/aws_cli_install
       - run:
-          name: setup local stack
-          command:
-            sh ./scripts/localstack/setup.sh
-      - run:
-          name: run gradlew check
+          name: Run Tests
           command:
             ./gradlew check
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,22 +22,71 @@ parameters:
     type: string
     default: hmpps-integration-api-alerts
 
+    parameters:
+      resource_class:
+        default: medium
+        type: string
+      jdk_tag:
+        type: string
+      localstack_tag:
+        type: string
+      localstack_type:
+        default: "localstack"
+        type: string
+      services:
+        default: "sqs,sns"
+        type: string
+      postgres_tag:
+        type: string
+      postgres_password:
+        default: "dev"
+        type: string
+      postgres_username:
+        default: "root"
+        type: string
+      postgres_port:
+        default: 5432
+        type: integer
+      java_options:
+        default: -Xmx512m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process -Dorg.gradle.workers.max=1
+        type: string
+
 jobs:
   validate:
-    executor:
-      name: hmpps/java_localstack_postgres_with_db_name
-      jdk_tag: "21.0"
-      localstack_tag: "3"
-      services: "sqs,sns,s3,secretsmanager"
-      postgres_tag: "15"
-#      postgres_db: << pipeline.parameters.postgres_name >>
-#      postgres_username: << pipeline.parameters.postgres_user >>
-#      postgres_password: << pipeline.parameters.postgres_password >>
-      resource_class: medium+
+#    executor:
+#      name: hmpps/java_localstack_postgres_with_db_name
+#      jdk_tag: "21.0"
+#      localstack_tag: "3"
+#      services: "sqs,sns,s3,secretsmanager"
+#      postgres_tag: "15"
+##      postgres_db: << pipeline.parameters.postgres_name >>
+##      postgres_username: << pipeline.parameters.postgres_user >>
+##      postgres_password: << pipeline.parameters.postgres_password >>
+#      resource_class: medium+
+#    environment:
+#      POSTGRES_NAME: "$DB_NAME"
+#      POSTGRES_USER: "$DB_USER"
+#      POSTGRES_PASSWORD: "$DB_PASSW"
+    docker:
+      - image: cimg/openjdk:21.0
+      - image: localstack/localstack:3
+        environment:
+          - SERVICES="sqs,sns,s3,secretsmanager"
+          - ES_PORT_EXTERNAL=4571
+          - DEBUG=${DEBUG- }
+          - DOCKER_HOST=unix:///var/run/docker.sock
+          - AWS_EXECUTION_ENV=True
+          - PERSISTENCE=1
+      - image: postgres:15
+        environment:
+          - POSTGRES_DB=${DB_NAME}
+          - POSTGRES_USER=${DB_USER}
+          - POSTGRES_PASSWORD=${DB_PASS}
+          - PGPORT=5432
     environment:
-      POSTGRES_NAME: "$DB_NAME"
-      POSTGRES_USER: "$DB_USER"
-      POSTGRES_PASSWORD: "$DB_PASSW"
+      _JAVA_OPTIONS: -Xmx512m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process -Dorg.gradle.workers.max=1
+    working_directory: ~/app
+    resource_class: medium+
     steps:
       - checkout
       - restore_cache:

--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,7 @@ fabric.properties
 *.tar.gz
 *.rar
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+# Virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
 Dockerrun.aws.json
@@ -68,12 +68,15 @@ dps-gradle-spring-boot-suppressions.xml
 .editorconfig
 sonar-project.properties
 
-#Helm
+# Helm
 **/Chart.lock
 
 # Localstack
 volume
 
-#Misc
+# Misc
 .DS_Store
+
+# Local development
+.env
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ serve:
 	docker-compose up --build -d
 
 unit-test:
-	DB_USER=${DB_USER} DB_PASS=${DB_PASS} API_KEY=${API_KEY} TEST_CLIENT_SECRET_NAME=${TEST_CLIENT_SECRET_NAME} ./gradlew test
+	DB_USER=${DB_USER} DB_PASS=${DB_PASS} API_KEY=${API_KEY} ./gradlew test
 
 lint:
 	./gradlew ktlintCheck
@@ -13,7 +13,8 @@ format:
 	./gradlew ktlintFormat
 
 check:
-	DB_USER=${DB_USER} DB_PASS=${DB_PASS} API_KEY=${API_KEY} TEST_CLIENT_SECRET_NAME=${TEST_CLIENT_SECRET_NAME} ./gradlew check
+	DB_USER=${DB_USER} DB_PASS=${DB_PASS} API_KEY=${API_KEY} ./gradlew check
 
 analyse-dependencies:
 	./gradlew dependencyCheckAnalyze --info
+T

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 include .env
 
+create-env-file:
+	./scripts/create-env-file.sh
+
 serve:
 	docker-compose up --build -d --wait
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ serve:
 	docker-compose up --build -d
 
 unit-test:
-	DB_USER=${DB_USER} DB_PASS=${DB_PASS} ./gradlew test
+	DB_USER=${DB_USER} DB_PASS=${DB_PASS} API_KEY=${API_KEY} TEST_CLIENT_SECRET_NAME=${TEST_CLIENT_SECRET_NAME} ./gradlew test
 
 lint:
 	./gradlew ktlintCheck
@@ -13,7 +13,7 @@ format:
 	./gradlew ktlintFormat
 
 check:
-	DB_USER=${DB_USER} DB_PASS=${DB_PASS} ./gradlew check
+	DB_USER=${DB_USER} DB_PASS=${DB_PASS} API_KEY=${API_KEY} TEST_CLIENT_SECRET_NAME=${TEST_CLIENT_SECRET_NAME} ./gradlew check
 
 analyse-dependencies:
 	./gradlew dependencyCheckAnalyze --info

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include .env
 
 serve:
-	docker-compose up --build -d
+	docker-compose up --build -d --wait
 
 unit-test:
 	DB_USER=${DB_USER} DB_PASS=${DB_PASS} API_KEY=${API_KEY} ./gradlew test
@@ -17,4 +17,3 @@ check:
 
 analyse-dependencies:
 	./gradlew dependencyCheckAnalyze --info
-T

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ serve:
 	docker-compose up --build -d
 
 unit-test:
-	DB_NAME=${DB_NAME} DB_USER=${DB_USER} DB_PASS=${DB_PASS} ./gradlew test
+	DB_USER=${DB_USER} DB_PASS=${DB_PASS} ./gradlew test
 
 lint:
 	./gradlew ktlintCheck
@@ -13,7 +13,7 @@ format:
 	./gradlew ktlintFormat
 
 check:
-	DB_NAME=${DB_NAME} DB_USER=${DB_USER} DB_PASS=${DB_PASS} ./gradlew check
+	DB_USER=${DB_USER} DB_PASS=${DB_PASS} ./gradlew check
 
 analyse-dependencies:
 	./gradlew dependencyCheckAnalyze --info

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
+include .env
+
 serve:
 	docker-compose up --build -d
 
 unit-test:
-	./gradlew test
+	DB_NAME=${DB_NAME} DB_USER=${DB_USER} DB_PASS=${DB_PASS} ./gradlew test
 
 lint:
 	./gradlew ktlintCheck
@@ -11,7 +13,7 @@ format:
 	./gradlew ktlintFormat
 
 check:
-	./gradlew check
+	DB_NAME=${DB_NAME} DB_USER=${DB_USER} DB_PASS=${DB_PASS} ./gradlew check
 
 analyse-dependencies:
 	./gradlew dependencyCheckAnalyze --info

--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ using IntelliJ but other IDEs will prove similar.
 3. Create a `.env` file in the root of the project and set the following values:
 
     ```
-    DB_NAME=  
     DB_USER=  
     DB_PASSWORD=  
     AWS_ACCESS_KEY_ID=  

--- a/README.md
+++ b/README.md
@@ -70,18 +70,7 @@ using IntelliJ but other IDEs will prove similar.
 
 2. Launch IntelliJ and open the `hmpps-integration-events` project by navigating to the location of the repository. Upon opening the project, IntelliJ will begin downloading and installing necessary dependencies which may take a few
    minutes.
-3. Create a `.env` file in the root of the project and set the following values:
-
-    ```
-    DB_USER=
-    DB_PASS=
-    API_KEY=
-    AWS_ACCESS_KEY_ID=
-    AWS_SECRET_ACCESS_KEY=
-    TEST_CLIENT_SECRET_VALUE=
-    ```
-    
-    These values are not real values, just ones that will be set on the local dependencies and in the application config. Ensure that this file **does not** get commited.
+3. Run `make create-env-file` to generate a `.env` file containing random values that will be set on the local dependencies and in the application config. Ensure that this file **does not** get commited.
 
 4. Obtain an API key for [hmpps-integration-api](https://github.com/ministryofjustice/hmpps-integration-api/tree/main) and set in [application-localstack.yml](src%2Fmain%2Fresources%2Fapplication-localstack.yml)
 5. Ensuring that docker is running within the root folder of the codebase, run the following command.

--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ using IntelliJ but other IDEs will prove similar.
 3. Create a `.env` file in the root of the project and set the following values:
 
     ```
-    DB_USER=  
-    DB_PASSWORD=  
-    AWS_ACCESS_KEY_ID=  
-    AWS_SECRET_ACCESS_KEY=  
-    TEST_CLIENT_SECRET_NAME=  
+    DB_USER=
+    DB_PASS=
+    API_KEY=
+    AWS_ACCESS_KEY_ID=
+    AWS_SECRET_ACCESS_KEY=
     TEST_CLIENT_SECRET_VALUE=
     ```
     

--- a/README.md
+++ b/README.md
@@ -64,21 +64,34 @@ using IntelliJ but other IDEs will prove similar.
 
 1. Clone the repo.
 
-```bash
-git clone git@github.com:ministryofjustice/hmpps-integration-events.git
-```
+    ```bash
+    git clone git@github.com:ministryofjustice/hmpps-integration-events.git
+    ```
 
 2. Launch IntelliJ and open the `hmpps-integration-events` project by navigating to the location of the repository. Upon opening the project, IntelliJ will begin downloading and installing necessary dependencies which may take a few
    minutes.
+3. Create a `.env` file in the root of the project and set the following values:
 
-3. Ensuring that docker is running within the root folder of the codebase run the command.
+    ```
+    DB_NAME=  
+    DB_USER=  
+    DB_PASSWORD=  
+    AWS_ACCESS_KEY_ID=  
+    AWS_SECRET_ACCESS_KEY=  
+    TEST_CLIENT_SECRET_NAME=  
+    TEST_CLIENT_SECRET_VALUE=
+    ```
+    
+    These values are not real values, just ones that will be set on the local dependencies and in the application config. Ensure that this file **does not** get commited.
+
 4. Obtain an API key for [hmpps-integration-api](https://github.com/ministryofjustice/hmpps-integration-api/tree/main) and set in [application-localstack.yml](src%2Fmain%2Fresources%2Fapplication-localstack.yml)
+5. Ensuring that docker is running within the root folder of the codebase, run the following command.
 
-```bash
-make serve
-```
-
-This will spin up the Spring Boot events application, Postgres DB and Localstack containers within Docker. For ease of development it may be easier to run the Spring Boot events application in IntelliJ to avoid having to spin up and down containers when you make changes. This can be done by creating a configuration file in IntelliJ with an active profile set as `localstack` and clicking the run button in the IDE.
+    ```bash
+    make serve
+    ```
+    
+    This will spin up the Spring Boot events application, Postgres DB and Localstack containers within Docker. For ease of development it may be easier to run the Spring Boot events application in IntelliJ to avoid having to spin up and down containers when you make changes. This can be done by creating a configuration file in IntelliJ with an active profile set as `localstack` and clicking the run button in the IDE.
 
 ### Running the tests
 
@@ -109,7 +122,9 @@ To run all the tests and linting:
 ```bash
 make check
 ```
+
 ## Developer guides
+
 - [Setting up a new consumer](docs%2Fguides%2Fsetting-up-a-new-consumer.md)
 
 ## Further documentation

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,11 @@ services:
     image: postgres:15
     container_name: hmpps-integration-events-db
     ports:
-      - 5432:5432
+      - "5432:5432"
     environment:
-      - POSTGRES_PASSWORD=pa55word
-      - POSTGRES_USER=postgres
-      - POSTGRES_DB=event_store
+      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
     networks:
       - hmpps
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "5432:5432"
     environment:
-      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_DB: event_store
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASS}
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     environment:
       POSTGRES_DB: ${DB_NAME}
       POSTGRES_USER: ${DB_USER}
-      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_PASSWORD: ${DB_PASS}
     networks:
       - hmpps
     healthcheck:

--- a/scripts/create-env-file.sh
+++ b/scripts/create-env-file.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Define the output .env file name
+ENV_FILE=".env"
+
+# Function to generate a random alphanumeric string of a specific length
+# $1: desired length of the random part of the string
+# $2: (optional) prefix for the string
+generate_random_string() {
+  local length=${1}
+  local prefix=${2:-} # Default to empty prefix if not provided
+  local random_chars=""
+
+  # Check if length is provided and is a positive number
+  if [[ -z "$length" || "$length" -le 0 ]]; then
+    echo "Error: Length must be a positive number for generate_random_string." >&2
+    return 1
+  fi
+
+  # Generate random characters using od (octal dump) for hex, then grep for desired range
+  # Read a bit more than needed to ensure enough random characters after filtering
+  # `od -x` gives hex, `tr -d ' '` removes spaces, then `grep -o '[0-9a-fA-F]'` filters to hex chars
+  # Then we just use those hex chars as our "random" string, or convert if truly alphanumeric needed
+  # For simple alphanumeric, we can generate a longer hex string and slice it.
+
+  # Simpler and more direct: generate hex and use that.
+  # This produces a string of [0-9a-f] characters.
+  # If you strictly need A-Z (uppercase) as well, it's slightly more complex.
+  # Let's generate a string of A-Za-z0-9
+  random_chars=$(head /dev/urandom | LC_ALL=C tr -dc 'A-Za-z0-9' | head -c "$length")
+
+  # Double-check the length, just in case (should be fine with LC_ALL=C now)
+  if [ ${#random_chars} -lt "$length" ]; then
+    # Fallback if the above still fails for some very rare reason or very short lengths
+    # This loop is slow but guarantees length and avoids `tr` errors with LC_ALL=C
+    local current_len=${#random_chars}
+    while [ "$current_len" -lt "$length" ]; do
+      random_chars+=$(LC_ALL=C head /dev/urandom | tr -dc 'A-Za-z0-9' | head -c 1)
+      current_len=${#random_chars}
+    done
+  fi
+
+  echo "${prefix}${random_chars:0:length}" # Ensure exact length
+}
+
+# Generate random values for each variable
+# Using appropriate lengths for typical use cases
+RANDOM_DB_USER="user_$(generate_random_string 8)" # 8 random chars after "user_"
+RANDOM_DB_PASS="$(generate_random_string 24)"    # 24 random chars for password
+RANDOM_API_KEY="api_$(generate_random_string 32)" # 32 random chars after "api_"
+RANDOM_AWS_ACCESS_KEY_ID="AKIA$(generate_random_string 16)" # AWS keys often start with AKIA, 16 random chars
+RANDOM_AWS_SECRET_ACCESS_KEY="$(generate_random_string 40)" # AWS secret keys are typically 40 random chars
+
+# Create or overwrite the .env file
+echo "# Generated on $(date)" > "${ENV_FILE}"
+echo "DB_USER=${RANDOM_DB_USER}" >> "${ENV_FILE}"
+echo "DB_PASS=${RANDOM_DB_PASS}" >> "${ENV_FILE}"
+echo "API_KEY=${RANDOM_API_KEY}" >> "${ENV_FILE}"
+echo "AWS_ACCESS_KEY_ID=${RANDOM_AWS_ACCESS_KEY_ID}" >> "${ENV_FILE}"
+echo "AWS_SECRET_ACCESS_KEY=${RANDOM_AWS_SECRET_ACCESS_KEY}" >> "${ENV_FILE}"
+
+echo "Generated ${ENV_FILE} with random values."
+echo "---"
+cat "${ENV_FILE}"

--- a/scripts/localstack/init/ready.d/setup.sh
+++ b/scripts/localstack/init/ready.d/setup.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 AWS_REGION="eu-west-2"
 BACK_UP_BUCKET="certificate-backup"
-TEST_CLIENT_SECRET="testSecret"
-TEST_CLIENT_SECRET_VALUE="{\"eventType\":[\"default\"]}"
-#Create certificate backup bucket
+TOPIC_FILTER_KEY="testSecret"
+TOPIC_FILTER_VALUE="{\"eventType\":[\"default\"]}"
+
+# Create certificate backup bucket
 awslocal s3 mb s3://$BACK_UP_BUCKET
-#Copy client certificate to bucket
+
+# Copy client certificate to bucket
 awslocal s3 cp "/etc/localstack/client.p12" "s3://certificate-backup/testclient/client.p12"
-awslocal secretsmanager create-secret --region $AWS_REGION --name $TEST_CLIENT_SECRET --description "Test Client Filter" --secret-string $TEST_CLIENT_SECRET_VALUE
+awslocal secretsmanager create-secret --region $AWS_REGION --name $TOPIC_FILTER_KEY --description "Test Client Filter" --secret-string $TOPIC_FILTER_VALUE

--- a/scripts/localstack/setup.sh
+++ b/scripts/localstack/setup.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 AWS_REGION="eu-west-2"
 BACK_UP_BUCKET="certificate-backup"
-TEST_CLIENT_SECRET_NAME="testSecret"
-TEST_CLIENT_SECRET_VALUE="{\"eventType\":[\"default\"]}"
+TOPIC_FILTER_VALUE="{\"eventType\":[\"default\"]}"
 
 echo "Checking environment variables are set"
 echo "AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID must be set}"
@@ -18,4 +17,4 @@ aws --endpoint-url=http://localhost:4566 s3 mb s3://$BACK_UP_BUCKET
 
 echo "Copying client certificate to bucket"
 aws --endpoint-url=http://localhost:4566 s3 cp "./scripts/localstack/client.p12" "s3://certificate-backup/testclient/client.p12"
-aws --endpoint-url=http://localhost:4566 secretsmanager create-secret --region $AWS_REGION --name $TEST_CLIENT_SECRET_NAME --description "Test Client Filter" --secret-string $TEST_CLIENT_SECRET_VALUE
+aws --endpoint-url=http://localhost:4566 secretsmanager create-secret --region $AWS_REGION --name "testSecret" --description "Test Client Filter" --secret-string $TOPIC_FILTER_VALUE

--- a/scripts/localstack/setup.sh
+++ b/scripts/localstack/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 AWS_REGION="eu-west-2"
 BACK_UP_BUCKET="certificate-backup"
-TOPIC_FILTER_KEY="testSecret"
+TOPIC_FILTER_KEY="test-client-id"
 TOPIC_FILTER_VALUE="{\"eventType\":[\"default\"]}"
 
 echo "Checking environment variables are set"

--- a/scripts/localstack/setup.sh
+++ b/scripts/localstack/setup.sh
@@ -9,8 +9,10 @@ TEST_CLIENT_SECRET_VALUE="{\"eventType\":[\"default\"]}"
 aws configure set region $AWS_REGION
 aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
 aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
-#Create certificate backup bucket
+
+# Create certificate backup bucket
 aws --endpoint-url=http://localhost:4566 s3 mb s3://$BACK_UP_BUCKET
-#Copy client certificate to bucket
+
+# Copy client certificate to bucket
 aws --endpoint-url=http://localhost:4566 s3 cp "./scripts/localstack/client.p12" "s3://certificate-backup/testclient/client.p12"
 aws --endpoint-url=http://localhost:4566 secretsmanager create-secret --region $AWS_REGION --name $TEST_CLIENT_SECRET --description "Test Client Filter" --secret-string $TEST_CLIENT_SECRET_VALUE

--- a/scripts/localstack/setup.sh
+++ b/scripts/localstack/setup.sh
@@ -1,18 +1,21 @@
 #!/bin/bash
 AWS_REGION="eu-west-2"
-AWS_ACCESS_KEY_ID="test"
-AWS_SECRET_ACCESS_KEY="test"
 BACK_UP_BUCKET="certificate-backup"
-TEST_CLIENT_SECRET="testSecret"
-TEST_CLIENT_SECRET_VALUE="{\"eventType\":[\"default\"]}"
 
+echo "Checking environment variables are set"
+echo "AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID must be set}"
+echo "AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY must be set}"
+echo "TEST_CLIENT_SECRET_NAME: ${TEST_CLIENT_SECRET_NAME:?TEST_CLIENT_SECRET_NAME must be set}"
+echo "TEST_CLIENT_SECRET_VALUE: ${TEST_CLIENT_SECRET_VALUE:?TEST_CLIENT_SECRET_VALUE must be set}"
+
+echo "Configuring AWS CLI"
 aws configure set region $AWS_REGION
 aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
 aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
 
-# Create certificate backup bucket
+echo "Creating certificate backup bucket"
 aws --endpoint-url=http://localhost:4566 s3 mb s3://$BACK_UP_BUCKET
 
-# Copy client certificate to bucket
+echo "Copying client certificate to bucket"
 aws --endpoint-url=http://localhost:4566 s3 cp "./scripts/localstack/client.p12" "s3://certificate-backup/testclient/client.p12"
-aws --endpoint-url=http://localhost:4566 secretsmanager create-secret --region $AWS_REGION --name $TEST_CLIENT_SECRET --description "Test Client Filter" --secret-string $TEST_CLIENT_SECRET_VALUE
+aws --endpoint-url=http://localhost:4566 secretsmanager create-secret --region $AWS_REGION --name $TEST_CLIENT_SECRET_NAME --description "Test Client Filter" --secret-string $TEST_CLIENT_SECRET_VALUE

--- a/scripts/localstack/setup.sh
+++ b/scripts/localstack/setup.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 AWS_REGION="eu-west-2"
 BACK_UP_BUCKET="certificate-backup"
+TEST_CLIENT_SECRET_NAME="testSecret"
 
 echo "Checking environment variables are set"
 echo "AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID must be set}"
 echo "AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY must be set}"
-echo "TEST_CLIENT_SECRET_NAME: ${TEST_CLIENT_SECRET_NAME:?TEST_CLIENT_SECRET_NAME must be set}"
 echo "TEST_CLIENT_SECRET_VALUE: ${TEST_CLIENT_SECRET_VALUE:?TEST_CLIENT_SECRET_VALUE must be set}"
 
 echo "Configuring AWS CLI"

--- a/scripts/localstack/setup.sh
+++ b/scripts/localstack/setup.sh
@@ -2,11 +2,11 @@
 AWS_REGION="eu-west-2"
 BACK_UP_BUCKET="certificate-backup"
 TEST_CLIENT_SECRET_NAME="testSecret"
+TEST_CLIENT_SECRET_VALUE="{\"eventType\":[\"default\"]}"
 
 echo "Checking environment variables are set"
 echo "AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID must be set}"
 echo "AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY must be set}"
-echo "TEST_CLIENT_SECRET_VALUE: ${TEST_CLIENT_SECRET_VALUE:?TEST_CLIENT_SECRET_VALUE must be set}"
 
 echo "Configuring AWS CLI"
 aws configure set region $AWS_REGION

--- a/scripts/localstack/setup.sh
+++ b/scripts/localstack/setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 AWS_REGION="eu-west-2"
 BACK_UP_BUCKET="certificate-backup"
+TOPIC_FILTER_KEY="testSecret"
 TOPIC_FILTER_VALUE="{\"eventType\":[\"default\"]}"
 
 echo "Checking environment variables are set"
@@ -17,4 +18,4 @@ aws --endpoint-url=http://localhost:4566 s3 mb s3://$BACK_UP_BUCKET
 
 echo "Copying client certificate to bucket"
 aws --endpoint-url=http://localhost:4566 s3 cp "./scripts/localstack/client.p12" "s3://certificate-backup/testclient/client.p12"
-aws --endpoint-url=http://localhost:4566 secretsmanager create-secret --region $AWS_REGION --name "testSecret" --description "Test Client Filter" --secret-string $TOPIC_FILTER_VALUE
+aws --endpoint-url=http://localhost:4566 secretsmanager create-secret --region $AWS_REGION --name $TOPIC_FILTER_KEY --description "Test Client Filter" --secret-string $TOPIC_FILTER_VALUE

--- a/src/main/resources/application-localstack.yml
+++ b/src/main/resources/application-localstack.yml
@@ -4,9 +4,9 @@ spring:
     hibernate:
       ddl-auto: create-drop
   datasource:
-    url: jdbc:postgresql://localhost:5432/event_store?sslmode=prefer
-    username: postgres
-    password: pa55word
+    url: "jdbc:postgresql://localhost:5432/${DB_NAME}?sslmode=prefer"
+    username: ${DB_USER}
+    password: ${DB_PASS}
   flyway:
     enabled: true
     baselineOnMigrate: true

--- a/src/main/resources/application-localstack.yml
+++ b/src/main/resources/application-localstack.yml
@@ -52,7 +52,7 @@ hmpps.secret:
   localstackUrl: http://localhost:4566
   secrets:
     mapps-client-org:
-      secretId: testSecret
+      secretId: test-client-id
       queueId: mappssubscriberqueue
 
 

--- a/src/main/resources/application-localstack.yml
+++ b/src/main/resources/application-localstack.yml
@@ -52,7 +52,7 @@ hmpps.secret:
   localstackUrl: http://localhost:4566
   secrets:
     mapps-client-org:
-      secretId: ${TEST_CLIENT_SECRET_NAME}
+      secretId: testSecret
       queueId: mappssubscriberqueue
 
 

--- a/src/main/resources/application-localstack.yml
+++ b/src/main/resources/application-localstack.yml
@@ -52,7 +52,7 @@ hmpps.secret:
   localstackUrl: http://localhost:4566
   secrets:
     mapps-client-org:
-      secretId: testSecret
+      secretId: ${TEST_CLIENT_SECRET_NAME}
       queueId: mappssubscriberqueue
 
 

--- a/src/main/resources/application-localstack.yml
+++ b/src/main/resources/application-localstack.yml
@@ -4,7 +4,7 @@ spring:
     hibernate:
       ddl-auto: create-drop
   datasource:
-    url: "jdbc:postgresql://localhost:5432/${DB_NAME}?sslmode=prefer"
+    url: "jdbc:postgresql://localhost:5432/event_store?sslmode=prefer"
     username: ${DB_USER}
     password: ${DB_PASS}
   flyway:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/services/EventSubscriberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/services/EventSubscriberTest.kt
@@ -31,9 +31,7 @@ import java.util.concurrent.TimeUnit
 @ExtendWith(SpringExtension::class)
 @SpringBootTest
 @ActiveProfiles("test")
-class EventSubscriberTest(
-  @Value("\${services.integration-api.apikey}") private val hmppsQueueUrl: String,
-) {
+class EventSubscriberTest {
   @Autowired
   lateinit var hmppsQueueService: HmppsQueueService
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/services/EventSubscriberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/services/EventSubscriberTest.kt
@@ -77,7 +77,7 @@ class EventSubscriberTest {
 
   @Test
   fun `Subscriber Service should update client filter list in secret and subscription`() {
-    val clientId = "mockservice1"
+    val clientId = "MOCKSERVICE1"
     val secret = hmppsSecretManagerProperties.secrets[clientId]
     val secretId = secret?.secretId
     secretId.shouldNotBeNull()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/services/EventSubscriberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/services/EventSubscriberTest.kt
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mockito.atLeast
 import org.mockito.Mockito.verify
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.bean.override.mockito.MockReset.BEFORE

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -20,7 +20,7 @@ spring:
 services:
   integration-api:
     url: https://localhost:8443
-    apikey: "mockApiKey"
+    apikey: ${API_KEY}
     certificate-bucket-name: "certificate-backup"
     certificate-password: "client"
     certificate-path: "testclient/client.p12"
@@ -71,7 +71,7 @@ hmpps.secret:
   localstackUrl: http://localhost:4566
   secrets:
     MOCKSERVICE1:
-      secret-id: testSecret
+      secret-id: ${TEST_CLIENT_SECRET_NAME}
       queueId: subscribertestqueue
 
 notifier:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -71,7 +71,7 @@ hmpps.secret:
   localstackUrl: http://localhost:4566
   secrets:
     MOCKSERVICE1:
-      secret-id: testSecret
+      secret-id: test-client-id
       queueId: subscribertestqueue
 
 notifier:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -7,9 +7,9 @@ management.endpoint:
 
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/event_store?sslmode=prefer
-    username: postgres
-    password: pa55word
+    url: "jdbc:postgresql://localhost:5432/${DB_NAME}?sslmode=prefer"
+    username: ${DB_USER}
+    password: ${DB_PASS}
   jpa:
     show-sql: true
     hibernate:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -7,7 +7,7 @@ management.endpoint:
 
 spring:
   datasource:
-    url: "jdbc:postgresql://localhost:5432/${DB_NAME}?sslmode=prefer"
+    url: "jdbc:postgresql://localhost:5432/event_store?sslmode=prefer"
     username: ${DB_USER}
     password: ${DB_PASS}
   jpa:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -71,7 +71,7 @@ hmpps.secret:
   localstackUrl: http://localhost:4566
   secrets:
     MOCKSERVICE1:
-      secret-id: ${TEST_CLIENT_SECRET_NAME}
+      secret-id: testSecret
       queueId: subscribertestqueue
 
 notifier:


### PR DESCRIPTION
#### Context

- We are hard coding localstack secrets and want to remove this as part of our efforts to improve the security of the application.

#### Changes proposed in this PR

- Application config files now use environment variables instead of hard coded values
- Docker Compose uses environment variables instead of hardcoded values, including the in the `scripts/localstack/setup.sh` file which is called in `docker-compose.yml`.
- Rewrote the `validate` job in CircleCI so it now uses a machine instead of Docker and then serves all of the test dependencies with Docker Compose instead of using MoJ orbs to do this. This simplifies things and also means that we aren't duplicating anything between our remote and local testing setups.
- Environment variables are injected into our test commands locally via our `Makefile` commands.
- Added documentation to the `README` outlining how to setup the `.env` file locally and the values that are required. Also created a new make command that will create this file with random values.