### PR TITLE
Removed non-association events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/enums/IntegrationEventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/enums/IntegrationEventType.kt
@@ -188,10 +188,10 @@ val PERSON_ADJUDICATION_EVENTS = listOf(
 
 val PERSON_NON_ASSOCIATION_EVENTS = listOf(
   HmppsDomainEventName.PrisonOffenderEvents.Prisoner.NonAssociationDetail.CHANGED,
-  HmppsDomainEventName.NonAssociations.CREATED,
-  HmppsDomainEventName.NonAssociations.AMENDED,
-  HmppsDomainEventName.NonAssociations.CLOSED,
-  HmppsDomainEventName.NonAssociations.DELETED,
+//  HmppsDomainEventName.NonAssociations.CREATED,
+//  HmppsDomainEventName.NonAssociations.AMENDED,
+//  HmppsDomainEventName.NonAssociations.CLOSED,
+//  HmppsDomainEventName.NonAssociations.DELETED,
 )
 
 val VISIT_CHANGED_EVENTS = listOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/listeners/HmppsDomainEventsListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/listeners/HmppsDomainEventsListenerIntegrationTest.kt
@@ -656,10 +656,10 @@ class HmppsDomainEventsListenerIntegrationTest : SqsIntegrationTestBase() {
   @ValueSource(
     strings = [
       HmppsDomainEventName.PrisonOffenderEvents.Prisoner.NonAssociationDetail.CHANGED,
-      HmppsDomainEventName.NonAssociations.CREATED,
-      HmppsDomainEventName.NonAssociations.AMENDED,
-      HmppsDomainEventName.NonAssociations.CLOSED,
-      HmppsDomainEventName.NonAssociations.DELETED,
+//      HmppsDomainEventName.NonAssociations.CREATED,
+//      HmppsDomainEventName.NonAssociations.AMENDED,
+//      HmppsDomainEventName.NonAssociations.CLOSED,
+//      HmppsDomainEventName.NonAssociations.DELETED,
     ],
   )
   fun `will process and save a non-association event SQS message`(eventType: String) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/NonAssociationsEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/NonAssociationsEventTest.kt
@@ -30,10 +30,10 @@ class NonAssociationsEventTest {
   @ValueSource(
     strings = [
       HmppsDomainEventName.PrisonOffenderEvents.Prisoner.NonAssociationDetail.CHANGED,
-      HmppsDomainEventName.NonAssociations.CREATED,
-      HmppsDomainEventName.NonAssociations.AMENDED,
-      HmppsDomainEventName.NonAssociations.CLOSED,
-      HmppsDomainEventName.NonAssociations.DELETED,
+//      HmppsDomainEventName.NonAssociations.CREATED,
+//      HmppsDomainEventName.NonAssociations.AMENDED,
+//      HmppsDomainEventName.NonAssociations.CLOSED,
+//      HmppsDomainEventName.NonAssociations.DELETED,
     ],
   )
   fun `will process an non-association notification`(eventType: String) {


### PR DESCRIPTION
#### Context

- Non-association events contains more than one hmppsId, we currently don't support this

#### Changes proposed in this PR

- Just leave the prisoner offender event for non-associations as the only events mapped to non-associations
- Comment out existing exists