### PR TITLE
HMAI-557 Add pre-commit hook to check for secrets

### DIFF
--- a/.github/workflows/security-scanning.yml
+++ b/.github/workflows/security-scanning.yml
@@ -1,0 +1,36 @@
+name: Security Scanning
+on: pull_request
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5.6.0
+        with:
+          python-version: '3.11'
+
+      - name: Set Python hash
+        run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'gradle'
+
+      - name: Cache pre-commit environments
+        uses: actions/cache@v4.2.3
+
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - name: Run pre-commit hooks
+        uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.17.0
+    hooks:
+      - id: gitleaks
+
+  - repo: local
+    hooks:
+      - id: ktlint-format
+        name: Formatting
+        entry: ./gradlew ktlintFormat
+        language: system
+        types: [kotlin]
+        stages: [pre-commit]
+        always_run: true
+        pass_filenames: false
+
+      - id: ktlint-check
+        name: Linting
+        entry: ./gradlew ktlintCheck
+        language: system
+        types: [kotlin]
+        stages: [pre-commit]
+        always_run: true
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -51,6 +51,19 @@ The [runbook](https://github.com/ministryofjustice/hmpps-integration-events/tree
 
 ## Get started locally
 
+1. Enable pre-commit hooks for formatting, linting, and secret scanning.
+
+   ```
+    # Install pipx if not already installed
+    brew install pipx
+    # Ensure the path to pipx-installed tools is active
+    pipx ensurepath
+    # Restart your terminal after running this
+    # Install pre-commit
+    pipx install pre-commit
+    # Install hooks into .git/hooks
+    pre-commit install
+   ```
 ### Local dependencies
 
 - [localstack](https://www.localstack.cloud/) a cloud software development framework to emulate AWS services.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.2.0"
+  id("org.jlleitschuh.gradle.ktlint") version "13.0.0-rc.1"
   kotlin("plugin.spring") version "2.1.21"
   kotlin("plugin.jpa") version "2.1.21"
   kotlin("plugin.lombok") version "2.1.21"


### PR DESCRIPTION
#### Context

- Security scanning is required to check for mistakenly exposed secrets

#### Changes proposed in this PR

- Pre-commit hooks were added for linting and security scanning, also in github actions