### PR TITLE
HMAI-580 - Add location events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/enums/IntegrationEventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/enums/IntegrationEventType.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums
 
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.exceptions.NotFoundException
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.HmppsDomainEventName
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.RegisterTypes.CHILD_CONCERNS_CODE
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.RegisterTypes.CHILD_PROTECTION_CODE
@@ -454,8 +455,14 @@ enum class IntegrationEventType(
   ),
   ;
 
-  fun path(hmppsId: String, prisonId: String?, additionalInformation: AdditionalInformation?): String {
-    var replacedPath = pathTemplate.replace("{hmppsId}", hmppsId)
+  fun path(hmppsId: String?, prisonId: String?, additionalInformation: AdditionalInformation?): String {
+    var replacedPath = pathTemplate
+    if (replacedPath.contains("{hmppsId}")) {
+      if (hmppsId == null) {
+        throw NotFoundException("Identifier could not be found in domain event message")
+      }
+      replacedPath = replacedPath.replace("{hmppsId}", hmppsId)
+    }
     if (prisonId != null) replacedPath = replacedPath.replace("{prisonId}", prisonId)
     additionalInformation?.let {
       if (it.contactPersonId != null) replacedPath = replacedPath.replace("{contactId}", it.contactPersonId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/enums/IntegrationEventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/enums/IntegrationEventType.kt
@@ -459,7 +459,12 @@ enum class IntegrationEventType(
       }
       replacedPath = replacedPath.replace("{hmppsId}", hmppsId)
     }
-    if (prisonId != null) replacedPath = replacedPath.replace("{prisonId}", prisonId)
+    if (replacedPath.contains("{prisonId}")) {
+      if (prisonId == null) {
+        throw NotFoundException("Prison ID could not be found in domain event message")
+      }
+      replacedPath = replacedPath.replace("{prisonId}", prisonId)
+    }
     additionalInformation?.let {
       if (it.contactPersonId != null) replacedPath = replacedPath.replace("{contactId}", it.contactPersonId)
       if (it.reference != null) replacedPath = replacedPath.replace("{visitReference}", it.reference)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/enums/IntegrationEventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/enums/IntegrationEventType.kt
@@ -404,29 +404,25 @@ enum class IntegrationEventType(
   PRISON_RESIDENTIAL_HIERARCHY_CHANGED(
     "v1/prison/{prisonId}/residential-hierarchy",
     {
-      false
-      // LOCATION_EVENTS.contains(it.eventType)
+      LOCATION_EVENTS.contains(it.eventType)
     },
   ),
   PRISON_LOCATION_CHANGED(
     "v1/prison/{prisonId}/location/{locationKey}",
     {
-      false
-      // LOCATION_EVENTS.contains(it.eventType)
+      LOCATION_EVENTS.contains(it.eventType)
     },
   ),
   PRISON_RESIDENTIAL_DETAILS_CHANGED(
     "v1/prison/{prisonId}/residential-details",
     {
-      false
-      // LOCATION_EVENTS.contains(it.eventType)
+      LOCATION_EVENTS.contains(it.eventType)
     },
   ),
   PRISON_CAPACITY_CHANGED(
     "v1/prison/{prisonId}/capacity",
     {
-      false
-      // PRISON_CAPACITY_EVENTS.contains(it.eventType)
+      PRISON_CAPACITY_EVENTS.contains(it.eventType)
     },
   ),
   VISIT_CHANGED(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/HmppsDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/HmppsDomainEventService.kt
@@ -28,7 +28,7 @@ class HmppsDomainEventService(
 
   fun execute(hmppsDomainEvent: HmppsDomainEvent, integrationEventTypes: List<IntegrationEventType>) {
     val hmppsEvent: HmppsDomainEventMessage = objectMapper.readValue(hmppsDomainEvent.message)
-    val hmppsId = getHmppsId(hmppsEvent) ?: throw NotFoundException("Identifier could not be found in domain event message ${hmppsDomainEvent.messageId}")
+    val hmppsId = getHmppsId(hmppsEvent)
     val prisonId = getPrisonId(hmppsEvent)
 
     for (integrationEventType in integrationEventTypes) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/HmppsDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/HmppsDomainEventService.kt
@@ -79,7 +79,8 @@ class HmppsDomainEventService(
   }
 
   private fun getPrisonId(hmppsEvent: HmppsDomainEventMessage): String? {
-    val prisonId = hmppsEvent.prisonId ?: hmppsEvent.additionalInformation?.prisonId
+    val prisonId = hmppsEvent.prisonId
+      ?: hmppsEvent.additionalInformation?.prisonId
     if (prisonId != null) {
       return prisonId
     }
@@ -87,6 +88,15 @@ class HmppsDomainEventService(
     val nomsNumber = getNomisNumber(hmppsEvent)
     if (nomsNumber != null) {
       return getPrisonIdService.execute(nomsNumber)
+    }
+
+    val locationKey = hmppsEvent.additionalInformation?.key
+    if (locationKey != null) {
+      val regex = Regex("^[A-Z]*((?=-)|$)")
+      val match = regex.find(locationKey)
+      if (match != null) {
+        return match.groups.first()?.value
+      }
     }
 
     return null

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/listeners/HmppsDomainEventsListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/listeners/HmppsDomainEventsListenerIntegrationTest.kt
@@ -749,17 +749,13 @@ class HmppsDomainEventsListenerIntegrationTest : SqsIntegrationTestBase() {
     val eventTypes = savedEvents.map { it.eventType }
     val urls = savedEvents.map { it.url }
 
-    savedEvents.size.shouldBe(3)
-    eventTypes.shouldContainExactlyInAnyOrder(
-      IntegrationEventType.PRISON_LOCATION_CHANGED,
-      IntegrationEventType.PRISON_RESIDENTIAL_HIERARCHY_CHANGED,
-      IntegrationEventType.PRISON_RESIDENTIAL_DETAILS_CHANGED,
-    )
-    urls.shouldContainExactlyInAnyOrder(
-      "https://localhost:8443/v1/prison/$prisonId/location/$locationKey",
-      "https://localhost:8443/v1/prison/$prisonId/residential-hierarchy",
-      "https://localhost:8443/v1/prison/$prisonId/residential-details",
-    )
+    eventTypes.shouldContain(IntegrationEventType.PRISON_LOCATION_CHANGED)
+    eventTypes.shouldContain(IntegrationEventType.PRISON_RESIDENTIAL_HIERARCHY_CHANGED)
+    eventTypes.shouldContain(IntegrationEventType.PRISON_RESIDENTIAL_DETAILS_CHANGED)
+
+    urls.shouldContain("https://localhost:8443/v1/prison/$prisonId/location/$locationKey")
+    urls.shouldContain("https://localhost:8443/v1/prison/$prisonId/residential-hierarchy")
+    urls.shouldContain("https://localhost:8443/v1/prison/$prisonId/residential-details")
   }
 
   @ParameterizedTest

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/listeners/HmppsDomainEventsListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/listeners/HmppsDomainEventsListenerIntegrationTest.kt
@@ -729,7 +729,7 @@ class HmppsDomainEventsListenerIntegrationTest : SqsIntegrationTestBase() {
     ],
   )
   fun `will process and save a location event SQS message`(eventType: String) {
-    val locationKey = "MDI-001-01"
+    val locationKey = "$prisonId-001-01"
     val message = """
     {
       "eventType": "$eventType",
@@ -769,12 +769,16 @@ class HmppsDomainEventsListenerIntegrationTest : SqsIntegrationTestBase() {
     ],
   )
   fun `will process and save a prison capacity event SQS message`(eventType: String) {
+    val locationKey = "$prisonId-001-01"
     val message = """
     {
       "eventType": "$eventType",
       "version": "1.0",
       "description": "Locations – a location inside prison has been amended",
-      "occurredAt": "2024-08-14T12:33:34+01:00"
+      "occurredAt": "2024-08-14T12:33:34+01:00",
+      "additionalInformation": {
+        "key": "$locationKey"
+      }
     }
     """
     val rawMessage = SqsNotificationGeneratingHelper().generateRawDomainEvent(eventType, message)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/listeners/HmppsDomainEventsListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/listeners/HmppsDomainEventsListenerIntegrationTest.kt
@@ -9,7 +9,6 @@ import io.kotest.matchers.shouldBe
 import org.awaitility.Awaitility
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
@@ -719,7 +718,6 @@ class HmppsDomainEventsListenerIntegrationTest : SqsIntegrationTestBase() {
     savedEvents[0].url.shouldBe("https://localhost:8443/v1/prison/$prisonId/prisoners/$crn/non-associations")
   }
 
-  @Disabled("This won't work until we handle missing hmppsIds")
   @ParameterizedTest
   @ValueSource(
     strings = [
@@ -764,7 +762,6 @@ class HmppsDomainEventsListenerIntegrationTest : SqsIntegrationTestBase() {
     )
   }
 
-  @Disabled("This won't work until we handle missing hmppsIds")
   @ParameterizedTest
   @ValueSource(
     strings = [

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/LocationEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/LocationEventTest.kt
@@ -104,6 +104,6 @@ class LocationEventTest {
 
     hmppsDomainEventsListener.onDomainEvent(payload)
 
-    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, listOf(IntegrationEventType.PRISON_CAPACITY_CHANGED)) }
+    verify(exactly = 1) { hmppsDomainEventService.execute(hmppsDomainEvent, match { it.contains(IntegrationEventType.PRISON_CAPACITY_CHANGED) }) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/LocationEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/listeners/LocationEventTest.kt
@@ -5,7 +5,6 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.boot.test.autoconfigure.json.JsonTest
@@ -27,7 +26,6 @@ class LocationEventTest {
 
   private val locationKey = "MDI-001-01"
 
-  @Disabled("This won't work until we handle missing hmppsIds")
   @ParameterizedTest
   @ValueSource(
     strings = [
@@ -75,7 +73,6 @@ class LocationEventTest {
     }
   }
 
-  @Disabled("This won't work until we handle missing hmppsIds")
   @ParameterizedTest
   @ValueSource(
     strings = [

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/HmppsDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/HmppsDomainEventServiceTest.kt
@@ -150,7 +150,17 @@ class HmppsDomainEventServiceTest {
   }
 
   @Test
-  fun `will use the prison ID if it is found on the domain event`() {
+  fun `will not process and save a domain event message with no prisonId which requires a prisonId`() {
+    val event: HmppsDomainEvent = SqsNotificationGeneratingHelper(zonedCurrentDateTime).createHmppsDomainEvent(identifiers = "[{\"type\":\"PNC\",\"value\":\"2018/0123456X\"}]")
+
+    val exception = assertThrows<NotFoundException> { hmppsDomainEventService.execute(event, listOf(IntegrationEventType.PRISON_LOCATION_CHANGED)) }
+
+    verify { eventNotificationRepository wasNot Called }
+    assertThat(exception.message, equalTo("Prison ID could not be found in domain event message"))
+  }
+
+  @Test
+  fun `will not process if  found on the domain event`() {
     val prisonId = "MDI"
     val event: HmppsDomainEvent = SqsNotificationGeneratingHelper(zonedCurrentDateTime).createHmppsDomainEventWithPrisonId(eventType = "assessment.summary.produced", prisonId = prisonId)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/HmppsDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/HmppsDomainEventServiceTest.kt
@@ -119,8 +119,7 @@ class HmppsDomainEventServiceTest {
   fun `will process and save a domain registration event message with no CRN or no Nomis Number which doesn't require a hmppsId`() {
     val event: HmppsDomainEvent = SqsNotificationGeneratingHelper(zonedCurrentDateTime).createHmppsDomainEvent(identifiers = "[{\"type\":\"PNC\",\"value\":\"2018/0123456X\"}]")
 
-    assertDoesNotThrow { hmppsDomainEventService.execute(event, listOf(IntegrationEventType.PRISON_LOCATION_CHANGED)) }
-
+    assertDoesNotThrow { hmppsDomainEventService.execute(event, listOf(IntegrationEventType.PRISONERS_CHANGED)) }
     verify(exactly = 1) { eventNotificationRepository.insertOrUpdate(any()) }
   }
 
@@ -160,7 +159,7 @@ class HmppsDomainEventServiceTest {
   }
 
   @Test
-  fun `will not process if  found on the domain event`() {
+  fun `will use prisonId if found on the domain event`() {
     val prisonId = "MDI"
     val event: HmppsDomainEvent = SqsNotificationGeneratingHelper(zonedCurrentDateTime).createHmppsDomainEventWithPrisonId(eventType = "assessment.summary.produced", prisonId = prisonId)
 


### PR DESCRIPTION
#### Context

- Location event logic is in places but commented out with tests disabled
- This is because `hmppsId` is currently required or an exception is thrown

#### Changes proposed in this PR

- Move check on `hmppsId` to the `path` method - so if the `{hmppsId}` if part of the URL, it now will throw if it is not found
- We get the `prisonId` from the location key on the domain events (it is at the start of the key) - in future we can look to add prison ID to the domain events themselves
- Created check on `prisonId` in the `path` method - so if the `{prisonId}` if part of the URL, it now will throw if it is not found