### PR TITLE
HMAI-590 - Fix bug where make create-env-file would error if the .env file didn't already exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-include .env
+-include .env
 
 create-env-file:
 	./scripts/create-env-file.sh

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,19 @@
 create-env-file:
 	./scripts/create-env-file.sh
 
-serve:
+check-required-vars:
+	@echo "Checking for required environment variables..."
+	@if [ -z "${DB_USER}" ] || [ -z "${DB_PASS}" ] || [ -z "${API_KEY}" ]; then \
+		echo "Error: Required variables (DB_USER, DB_PASS, API_KEY) are not set."; \
+		echo "Please ensure they are defined in your .env file or environment. You can run make create-env-file to generate the .env file locally."; \
+		exit 1; \
+	fi
+	@echo "All required variables are set."
+
+serve: check-required-vars
 	docker-compose up --build -d --wait
 
-unit-test:
+unit-test: check-required-vars
 	DB_USER=${DB_USER} DB_PASS=${DB_PASS} API_KEY=${API_KEY} ./gradlew test
 
 lint:
@@ -15,7 +24,7 @@ lint:
 format:
 	./gradlew ktlintFormat
 
-check:
+check: check-required-vars
 	DB_USER=${DB_USER} DB_PASS=${DB_PASS} API_KEY=${API_KEY} ./gradlew check
 
 analyse-dependencies:


### PR DESCRIPTION
#### Context

- Running `make create-env-file` ironically breaks if the `.env` file doesn’t currently exist. This is due to it being required in the `Makefile` as it injects the environment variables into our test commands.

#### Changes proposed in this PR

- The `Makefile` now uses a soft include so it won't error if the `.env` file doesn't already exist when the `create-env-file` command is ran
- I have also added checks for required environment variables in all make commands where they are needed. If they aren't found you get a message like this in the terminal:

```
Error: Required variables (DB_USER, DB_PASS, API_KEY) are not set.
Please ensure they are defined in your .env file or environment. You can run make create-env-file to generate the .env file locally.
```