### PR TITLE
HMAI-621 - Fix Postgres CVE

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ configurations {
 
 dependencies {
   runtimeOnly("org.flywaydb:flyway-database-postgresql")
-  runtimeOnly("org.postgresql:postgresql")
+  runtimeOnly("org.postgresql:postgresql:42.7.7")
   runtimeOnly("org.flywaydb:flyway-core")
 
   annotationProcessor("org.projectlombok:lombok:1.18.38")


### PR DESCRIPTION
#### Context

Our latest trivy scan picked up a HIGH severity CVE in the `postgres` package.
- https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-integration-events/1060/workflows/541f6fa7-a988-442b-8658-36a4aa155128/jobs/2894
- https://github.com/pgjdbc/pgjdbc/security/advisories/GHSA-hq9p-pm7w-8p54

#### Changes proposed in this PR

- Bump `postgres' to version `42.7.7`