### PR TITLE
HMAI-640 - Update HMPPS Spring Gradle Plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.3.0-beta"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.3.0"
   kotlin("plugin.spring") version "2.1.21"
   kotlin("plugin.jpa") version "2.1.21"
   kotlin("plugin.lombok") version "2.1.21"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.2.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.3.0-beta"
   kotlin("plugin.spring") version "2.1.21"
   kotlin("plugin.jpa") version "2.1.21"
   kotlin("plugin.lombok") version "2.1.21"


### PR DESCRIPTION
Updates the uk.gov.justice.hmpps.gradle-spring-boot plugin to version `8.3.0` to see that it fixes our security alerts in CircleCI. The CVEs should all be patched by bumps to deps in the plugin.