### PR TITLE
[ESWE-1380] Generate integration events upon prisoner merged

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/HmppsDomainEventName.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/HmppsDomainEventName.kt
@@ -94,6 +94,7 @@ object HmppsDomainEventName {
       const val CONTACT_APPROVED = "prison-offender-events.prisoner.contact-approved"
       const val CONTACT_UNAPPROVED = "prison-offender-events.prisoner.contact-unapproved"
       const val CONTACT_REMOVED = "prison-offender-events.prisoner.contact-removed"
+      const val MERGED = "prison-offender-events.prisoner.merged"
       object Restriction {
         const val CHANGED = "prison-offender-events.prisoner.restriction.changed"
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/enums/IntegrationEventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/enums/IntegrationEventType.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums
 
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.exceptions.NotFoundException
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.HmppsDomainEventName
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.HmppsDomainEventName.PrisonOffenderEvents
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.RegisterTypes.CHILD_CONCERNS_CODE
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.RegisterTypes.CHILD_PROTECTION_CODE
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.RegisterTypes.HIGH_ROSH_CODE
@@ -261,11 +262,12 @@ enum class IntegrationEventType(
   PRISONER_BASE_LOCATION_CHANGED(
     "v1/persons/{hmppsId}/prisoner-base-location",
     {
-      with(HmppsDomainEventName.PrisonOffenderEvents.Prisoner) {
+      with(PrisonOffenderEvents.Prisoner) {
         when (it.eventType) {
           RECEIVED -> it.additionalInformation?.reason?.let { reason ->
             reason == ReceptionReasons.ADMISSION || reason == ReceptionReasons.TRANSFERRED
           } ?: false
+
           RELEASED -> it.additionalInformation?.reason?.equals(
             ReleaseReasons.RELEASED,
           ) ?: false
@@ -510,6 +512,10 @@ enum class IntegrationEventType(
   PERSON_LANGUAGES_CHANGED(
     "v1/persons/{hmppsId}/languages",
     { NEW_PERSON_EVENTS.contains(it.eventType) }, // No specific event found
+  ),
+  PRISONER_MERGE(
+    "v1/persons/{hmppsId}",
+    { PrisonOffenderEvents.Prisoner.MERGED == it.eventType },
   ),
   ;
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/registration/HmppsDomainEventMessage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/registration/HmppsDomainEventMessage.kt
@@ -42,6 +42,7 @@ data class AdditionalInformation(
   @JsonProperty("key") val key: String? = null,
   @JsonProperty("prisonId") val prisonId: String? = null,
   @JsonProperty("reason") val reason: String? = null,
+  @JsonProperty("removedNomsNumber") val removedNomsNumber: String? = null,
 ) {
   fun hasMatchingRegistrationType(registerTypeCode: List<String>): Boolean = (
     registerTypeCode.contains(this.registerTypeCode)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/repository/EventNotificationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/repository/EventNotificationRepository.kt
@@ -13,6 +13,8 @@ import java.time.LocalDateTime
 @Repository
 interface EventNotificationRepository : JpaRepository<EventNotification, Long> {
 
+  fun findByHmppsIdIsIn(hmppsIds: Collection<String>): List<EventNotification>
+
   @Query("select a from EventNotification a where a.lastModifiedDateTime <= :dateTime")
   fun findAllWithLastModifiedDateTimeBefore(
     @Param("dateTime") dateTime: LocalDateTime?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/DomainEventIdentitiesResolver.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/DomainEventIdentitiesResolver.kt
@@ -1,0 +1,72 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationevents.services
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.exceptions.NotFoundException
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.gateway.ProbationIntegrationApiGateway
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.registration.HmppsDomainEventMessage
+
+@Service
+class DomainEventIdentitiesResolver(
+  @Autowired val probationIntegrationApiGateway: ProbationIntegrationApiGateway,
+  @Autowired val getPrisonIdService: GetPrisonIdService,
+) {
+
+  /**
+   * The hmpps id is an id that the end client will use in ongoing processing.
+   * In the future when we have a core person record it will be that id
+   * for now the id will default to the crn but if there is no crn it will be the noms number.
+   * The end client that receives the messages must treat it as a hmpps_id and NOT a crn/noms number.
+   * A look-up service exist to decode the hmpps_id into a crn or noms number.
+   */
+  fun getHmppsId(hmppsEvent: HmppsDomainEventMessage): String? {
+    val crn: String? = hmppsEvent.personReference?.findCrnIdentifier()
+    if (crn != null) {
+      probationIntegrationApiGateway.getPersonExists(crn).let {
+        if (it.existsInDelius) {
+          return crn
+        }
+        throw NotFoundException("Person with crn $crn not found")
+      }
+    }
+
+    val nomsNumber = getNomisNumber(hmppsEvent)
+
+    return nomsNumber?.let { noms ->
+      probationIntegrationApiGateway.getPersonIdentifier(noms)?.crn ?: noms
+    }
+  }
+
+  fun getPrisonId(hmppsEvent: HmppsDomainEventMessage): String? {
+    val prisonId = hmppsEvent.prisonId
+      ?: hmppsEvent.additionalInformation?.prisonId
+    if (prisonId != null) {
+      return prisonId
+    }
+
+    val nomsNumber = getNomisNumber(hmppsEvent)
+    if (nomsNumber != null) {
+      return getPrisonIdService.execute(nomsNumber)
+    }
+
+    val locationKey = hmppsEvent.additionalInformation?.key
+    if (locationKey != null) {
+      val regex = Regex("^[A-Z]*((?=-)|$)")
+      val match = regex.find(locationKey)
+      if (match != null) {
+        return match.groups.first()?.value
+      }
+    }
+    return null
+  }
+
+  private fun getNomisNumber(hmppsEvent: HmppsDomainEventMessage): String? {
+    val nomsNumber = hmppsEvent.personReference?.findNomsIdentifier()
+      ?: hmppsEvent.additionalInformation?.nomsNumber
+      ?: hmppsEvent.additionalInformation?.prisonerId
+      ?: hmppsEvent.additionalInformation?.prisonerNumber
+      ?: hmppsEvent.prisonerId
+
+    return nomsNumber
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/HmppsDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/HmppsDomainEventService.kt
@@ -6,99 +6,29 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.hmppsintegrationevents.exceptions.NotFoundException
-import uk.gov.justice.digital.hmpps.hmppsintegrationevents.gateway.ProbationIntegrationApiGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.HmppsDomainEvent
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventType
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.registration.HmppsDomainEventMessage
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.repository.EventNotificationRepository
-import uk.gov.justice.digital.hmpps.hmppsintegrationevents.repository.model.data.EventNotification
-import java.time.LocalDateTime
 
 @Service
 @Configuration
 class HmppsDomainEventService(
   @Autowired val eventNotificationRepository: EventNotificationRepository,
   @Autowired val deadLetterQueueService: DeadLetterQueueService,
-  @Autowired val probationIntegrationApiGateway: ProbationIntegrationApiGateway,
-  @Autowired val getPrisonIdService: GetPrisonIdService,
+  @Autowired val integrationEventCreationStrategyProvider: IntegrationEventCreationStrategyProvider,
   @Value("\${services.integration-api.url}") val baseUrl: String,
 ) {
   private val objectMapper = ObjectMapper()
 
   fun execute(hmppsDomainEvent: HmppsDomainEvent, integrationEventTypes: List<IntegrationEventType>) {
     val hmppsEvent: HmppsDomainEventMessage = objectMapper.readValue(hmppsDomainEvent.message)
-    val hmppsId = getHmppsId(hmppsEvent)
-    val prisonId = getPrisonId(hmppsEvent)
-
     for (integrationEventType in integrationEventTypes) {
-      val eventNotification = EventNotification(
-        eventType = integrationEventType,
-        hmppsId = hmppsId,
-        prisonId = prisonId,
-        url = "$baseUrl/${integrationEventType.path(hmppsId, prisonId,hmppsEvent.additionalInformation)}",
-        lastModifiedDateTime = LocalDateTime.now(),
-      )
-      eventNotificationRepository.insertOrUpdate(eventNotification)
-    }
-  }
-
-  /**
-   * The hmpps id is an id that the end client will use in ongoing processing.
-   * In the future when we have a core person record it will be that id
-   * for now the id will default to the crn but if there is no crn it will be the noms number.
-   * The end client that receives the messages must treat it as a hmpps_id and NOT a crn/noms number.
-   * A look-up service exist to decode the hmpps_id into a crn or noms number.
-   */
-  private fun getHmppsId(hmppsEvent: HmppsDomainEventMessage): String? {
-    val crn: String? = hmppsEvent.personReference?.findCrnIdentifier()
-    if (crn != null) {
-      probationIntegrationApiGateway.getPersonExists(crn).let {
-        if (it.existsInDelius) {
-          return crn
-        }
-        throw NotFoundException("Person with crn $crn not found")
+      val notifications = integrationEventCreationStrategyProvider.forEventType(integrationEventType)
+        .createNotifications(hmppsEvent, integrationEventType, baseUrl)
+      for (notification in notifications) {
+        eventNotificationRepository.insertOrUpdate(notification)
       }
     }
-
-    val nomsNumber = getNomisNumber(hmppsEvent)
-
-    return nomsNumber?.let { noms ->
-      probationIntegrationApiGateway.getPersonIdentifier(noms)?.crn ?: noms
-    }
-  }
-
-  private fun getNomisNumber(hmppsEvent: HmppsDomainEventMessage): String? {
-    val nomsNumber = hmppsEvent.personReference?.findNomsIdentifier()
-      ?: hmppsEvent.additionalInformation?.nomsNumber
-      ?: hmppsEvent.additionalInformation?.prisonerId
-      ?: hmppsEvent.additionalInformation?.prisonerNumber
-      ?: hmppsEvent.prisonerId
-
-    return nomsNumber
-  }
-
-  private fun getPrisonId(hmppsEvent: HmppsDomainEventMessage): String? {
-    val prisonId = hmppsEvent.prisonId
-      ?: hmppsEvent.additionalInformation?.prisonId
-    if (prisonId != null) {
-      return prisonId
-    }
-
-    val nomsNumber = getNomisNumber(hmppsEvent)
-    if (nomsNumber != null) {
-      return getPrisonIdService.execute(nomsNumber)
-    }
-
-    val locationKey = hmppsEvent.additionalInformation?.key
-    if (locationKey != null) {
-      val regex = Regex("^[A-Z]*((?=-)|$)")
-      val match = regex.find(locationKey)
-      if (match != null) {
-        return match.groups.first()?.value
-      }
-    }
-
-    return null
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/IntegrationEventCreationStrategy.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/IntegrationEventCreationStrategy.kt
@@ -1,0 +1,79 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationevents.services
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventType
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.registration.HmppsDomainEventMessage
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.repository.model.data.EventNotification
+import java.time.LocalDateTime
+
+interface IntegrationEventCreationStrategy {
+  fun createNotifications(
+    hmppsDomainEventMessage: HmppsDomainEventMessage,
+    integrationEventType: IntegrationEventType,
+    baseUrl: String,
+  ): List<EventNotification>
+}
+
+open class BaseStrategy(private val domainEventIdentitiesResolver: DomainEventIdentitiesResolver) {
+  protected fun getHmppsId(message: HmppsDomainEventMessage): String? = domainEventIdentitiesResolver.getHmppsId(message)
+  protected fun getPrisonId(message: HmppsDomainEventMessage): String? = domainEventIdentitiesResolver.getPrisonId(message)
+}
+
+@Component
+class DefaultEventCreationStrategy(domainEventIdentitiesResolver: DomainEventIdentitiesResolver) :
+  BaseStrategy(domainEventIdentitiesResolver),
+  IntegrationEventCreationStrategy {
+  override fun createNotifications(
+    hmppsDomainEventMessage: HmppsDomainEventMessage,
+    integrationEventType: IntegrationEventType,
+    baseUrl: String,
+  ): List<EventNotification> = listOf(
+    notification(
+      integrationEventType,
+      hmppsDomainEventMessage,
+      getHmppsId(hmppsDomainEventMessage),
+      getPrisonId(hmppsDomainEventMessage),
+      baseUrl,
+    ),
+  )
+}
+
+@Component
+class MultipleEventCreationStrategy(domainEventIdentitiesResolver: DomainEventIdentitiesResolver) :
+  BaseStrategy(domainEventIdentitiesResolver),
+  IntegrationEventCreationStrategy {
+  override fun createNotifications(
+    hmppsDomainEventMessage: HmppsDomainEventMessage,
+    integrationEventType: IntegrationEventType,
+    baseUrl: String,
+  ): List<EventNotification> = listOf(
+    notification(
+      integrationEventType,
+      hmppsDomainEventMessage,
+      hmppsDomainEventMessage.additionalInformation?.removedNomsNumber,
+      getPrisonId(hmppsDomainEventMessage),
+      baseUrl,
+    ),
+    notification(
+      integrationEventType,
+      hmppsDomainEventMessage,
+      hmppsDomainEventMessage.additionalInformation?.nomsNumber,
+      getPrisonId(hmppsDomainEventMessage),
+      baseUrl,
+    ),
+  )
+}
+
+private fun notification(
+  integrationEventType: IntegrationEventType,
+  hmppsDomainEventMessage: HmppsDomainEventMessage,
+  hmppsId: String?,
+  prisonId: String?,
+  baseUrl: String,
+): EventNotification = EventNotification(
+  eventType = integrationEventType,
+  hmppsId = hmppsId,
+  prisonId = prisonId,
+  url = "$baseUrl/${integrationEventType.path(hmppsId, prisonId, hmppsDomainEventMessage.additionalInformation)}",
+  lastModifiedDateTime = LocalDateTime.now(),
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/IntegrationEventCreationStrategyProvider.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/IntegrationEventCreationStrategyProvider.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationevents.services
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventType
+
+@Service
+class IntegrationEventCreationStrategyProvider(
+  @Autowired private val singleEmissionStrategy: DefaultEventCreationStrategy,
+  @Autowired private val multipleEmissionStrategy: MultipleEventCreationStrategy,
+) {
+  fun forEventType(eventType: IntegrationEventType): IntegrationEventCreationStrategy = when (eventType) {
+    IntegrationEventType.PRISONER_MERGE -> multipleEmissionStrategy
+    else -> singleEmissionStrategy
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/helpers/SqsNotificationGeneratingHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/helpers/SqsNotificationGeneratingHelper.kt
@@ -78,6 +78,32 @@ class SqsNotificationGeneratingHelper(timestamp: ZonedDateTime = LocalDateTime.n
     """
     )
 
+  fun generateRawHmppsMergeDomainEvent(
+    eventType: String = "prison-offender-events.prisoner.merged",
+    nomsId: String = "A3646EA",
+    removedNomsId: String = "A3646EB",
+    messageEventType: String = eventType,
+  ): String = (
+    """
+    {
+     "Type" : "Notification",
+     "MessageId" : "1a2345bc-de67-890f-1g01-11h21314h151",
+     "TopicArn" : "arn:aws:sns:eu-west-2:123456789123:cloud-platform-Digital-Prison-Services-12a3456bc12345a1a12345ab3c123b12",
+     "Message" : "{\"eventType\":\"$messageEventType\",\"version\":1,\"occurredAt\":\"$isoInstantTimestamp\",\"description\":\"A prisoner has been merged from $removedNomsId to $nomsId\",\"additionalInformation\": {\"bookingId\": \"1216772\", \"nomsNumber\": \"$nomsId\", \"reason\": \"MERGE\", \"removedNomsNumber\": \"$removedNomsId\"}, \"personReference\": {\"identifiers\": [{\"type\": \"NOMS\", \"value\": \"$nomsId\"}]}}",
+     "Timestamp" : "$isoInstantTimestamp",
+     "SignatureVersion" : "1",
+     "Signature" : "A5cK8hNQj+3PTeLwS9D4bFYUvz1aI6cGvT2XWmRkE+7MoJZniFQjDeo2tI3BwKhLI9RXznGvZD1KbOoEMp4kUqBnA2Wr3bH5D6NfYhJKYV8sGpVcWzUMlTgbxErC1L7RgM2o7bHWlCKqfzOiDRsLpPeuJElmuTcYJtn+Lxv3R4TyYndafQSoVpErHcRJwWjDSf5l6jrKVa4m0NQbgtyZlxVPcHYf+wpWcuJ1BvLSnDHM+egRw7GqpxDB+IU1kEolC3eL4RUjXGmkQ9YtczF2P1JrThsRi0oEgnp7f/VtB6oqOKkYvlMXaF/+uhdwZbWlDa/83HcYV9MkJpWpx8UeisflEMNt57hbJXIgGQvsTYo4cRn9VgWQJxb6yDw8zS+I6yuGNbcL5L2Aj+whsEM1ovcR7KBPvgsMlxtCyVYzj36sDa4nUfiR5iZkVDeT==",
+     "SigningCertURL" : "https://sns.eu-west-2.amazonaws.com/SimpleNotificationService-12abcd123456d12b1e23a123456ef123.pem",
+     "UnsubscribeURL" : "https://sns.eu-west-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-2:123456789123:cloud-platform-Digital-Prison-Services-12a3456bc12345a1a12345ab3c123b12:123b456a-123f-1234-a123-123456789d10",
+     "MessageAttributes" : {
+       "eventType" : {"Type":"String","Value":"$eventType"},
+       "id" : {"Type":"String","Value":"12345678-a1af-a0ba-1b22-d12e12d1234f"},
+       "timestamp" : {"Type":"Number.java.lang.Long","Value":"$millis"}
+     }
+    }
+    """
+    )
+
   fun generateRawHmppsDomainEventWithoutRegisterType(
     eventType: String,
     identifiers: String = "[{\\\"type\\\":\\\"CRN\\\",\\\"value\\\":\\\"X777776\\\"}]",
@@ -172,6 +198,19 @@ class SqsNotificationGeneratingHelper(timestamp: ZonedDateTime = LocalDateTime.n
   ): HmppsDomainEvent = HmppsDomainEvent(
     type = "Notification",
     message = "{\"eventType\":\"$eventType\",\"version\":1,\"occurredAt\":\"$isoInstantTimestamp\",\"description\":\"A new registration has been added to the probation case\",\"prisonId\":\"$prisonId\",\"personReference\":{\"identifiers\":$identifiers},\"additionalInformation\":{\"registrationLevelDescription\":\"MAPPA Level 3\",\"registerTypeDescription\":\"MAPPA\",\"registrationCategoryCode\":\"M1\",\"registrationId\":\"1234567890\",\"registrationDate\":\"$readableTimestamp\",\"registerTypeCode\":\"$registerTypeCode\",\"createdDateAndTime\":\"$readableTimestamp\",\"registrationCategoryDescription\":\"MAPPA Cat 1\",\"registrationLevelCode\":\"M3\"}}",
+    messageId = "1a2345bc-de67-890f-1g01-11h21314h151",
+    messageAttributes = DomainEventMessageAttributes(eventType = EventType(value = attributeEventTypes)),
+  )
+
+  fun createHmppsMergedDomainEvent(
+    eventType: String = "prison-offender-events.prisoner.merged",
+    identifiers: String = "[{\"type\":\"NOMS\",\"value\":\"A3645EA\"}]",
+    attributeEventTypes: String = eventType,
+    nomisNumber: String,
+    removedNomisNumber: String,
+  ): HmppsDomainEvent = HmppsDomainEvent(
+    type = "Notification",
+    message = "{\"eventType\":\"$eventType\",\"version\":1,\"occurredAt\":\"$isoInstantTimestamp\",\"description\":\"A prisoner has been merged from $removedNomisNumber to $nomisNumber\",\"personReference\":{\"identifiers\":$identifiers},\"additionalInformation\": {\"bookingId\": \"1216772\", \"nomsNumber\": \"$nomisNumber\", \"reason\": \"MERGE\", \"removedNomsNumber\": \"$removedNomisNumber\"}}",
     messageId = "1a2345bc-de67-890f-1g01-11h21314h151",
     messageAttributes = DomainEventMessageAttributes(eventType = EventType(value = attributeEventTypes)),
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/DefaultEventCreationStrategyTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/DefaultEventCreationStrategyTest.kt
@@ -1,0 +1,295 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationevents.services
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.exceptions.NotFoundException
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents.PRISONER_OFFENDER_SEARCH_PRISONER_CREATED
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents.PRISONER_OFFENDER_SEARCH_PRISONER_UPDATED
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents.PROBATION_CASE_ENGAGEMENT_CREATED_MESSAGE
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents.PROBATION_CASE_PRISON_IDENTIFIER_ADDED
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents.generateHmppsDomainEvent
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.SqsNotificationGeneratingHelper
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.HmppsDomainEvent
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventType
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.registration.HmppsDomainEventMessage
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.repository.model.data.EventNotification
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.util.stream.Stream
+
+class DefaultEventCreationStrategyTest {
+
+  private val domainEventIdentitiesResolver = mockk<DomainEventIdentitiesResolver>()
+  private val objectMapper = ObjectMapper()
+  private val hmppsId = "X777776"
+  private val prisonId = "LEI"
+  private val baseUrl = "https://event-service.test"
+  private var eventType = IntegrationEventType.PRISONER_CHANGED
+  private val currentTime: LocalDateTime = LocalDateTime.now()
+  private val zonedCurrentDateTime = currentTime.atZone(ZoneId.systemDefault())
+  private var domainMessage = HmppsDomainEventMessage(
+    eventType = eventType.name,
+    occurredAt = "2024-08-13T14:15:16.460942253+01:00",
+    prisonId = prisonId,
+    personReference = null,
+    additionalInformation = null,
+  )
+
+  private lateinit var strategy: DefaultEventCreationStrategy
+
+  @BeforeEach
+  fun setup() {
+    strategy = DefaultEventCreationStrategy(domainEventIdentitiesResolver)
+
+    every { domainEventIdentitiesResolver.getHmppsId(any()) } returns hmppsId
+    every { domainEventIdentitiesResolver.getPrisonId(any()) } returns prisonId
+  }
+
+  @Test
+  fun `should create a notification with resolved HMPPS ID and prison ID`() {
+    val domainEvent: HmppsDomainEvent =
+      SqsNotificationGeneratingHelper(zonedCurrentDateTime).createHmppsDomainEventWithPrisonId(
+        eventType = "assessment.summary.produced",
+        prisonId = prisonId,
+      )
+    domainMessage = objectMapper.readValue(domainEvent.message)
+
+    val notifications = strategy.createNotifications(domainMessage, eventType, baseUrl)
+
+    verify { domainEventIdentitiesResolver.getHmppsId(domainMessage) }
+    verify { domainEventIdentitiesResolver.getPrisonId(domainMessage) }
+
+    assertThat(notifications.size).isEqualTo(1)
+    val notification = notifications[0]
+    assertThat(notification)
+      .extracting(
+        EventNotification::eventType,
+        EventNotification::hmppsId,
+        EventNotification::url,
+      ).containsExactly(
+        IntegrationEventType.PRISONER_CHANGED,
+        hmppsId,
+        "$baseUrl/v1/prison/prisoners/$hmppsId",
+      )
+    assertThat(notification.eventType).isEqualTo(eventType)
+    assertThat(notification.hmppsId).isEqualTo(hmppsId)
+    assertThat(notification.prisonId).isEqualTo(prisonId)
+    assertThat(notification.lastModifiedDateTime).isNotNull
+    assertThat(notification.url).contains(hmppsId)
+  }
+
+  @ParameterizedTest
+  @MethodSource("eventTypeAndIntegrationEventTypeProvider")
+  fun `process event processing for api persons {hmppsId} `(domainEventType: String, hmppsMessageJson: String) {
+    val hmppsMessage = hmppsMessageJson.replace("\\", "")
+    val domainEvent = generateHmppsDomainEvent(domainEventType, hmppsMessage)
+    domainMessage = objectMapper.readValue(domainEvent.message)
+
+    every { domainEventIdentitiesResolver.getHmppsId(domainMessage) } returns "X777776" andThen "A1234BC"
+    every { domainEventIdentitiesResolver.getPrisonId(domainMessage) } returns null
+
+    val notifications = strategy.createNotifications(
+      domainMessage,
+      IntegrationEventType.PERSON_STATUS_CHANGED,
+      baseUrl,
+    )
+
+    assertThat(notifications.size).isEqualTo(1)
+    val notification = notifications[0]
+    assertThat(notification)
+      .extracting(EventNotification::eventType, EventNotification::hmppsId, EventNotification::url)
+      .containsExactly(
+        IntegrationEventType.PERSON_STATUS_CHANGED,
+        "X777776",
+        "$baseUrl/v1/persons/X777776",
+      )
+    assertThat(notification.lastModifiedDateTime).isAfterOrEqualTo(currentTime)
+  }
+
+  @Test
+  fun `should throw exception for a domain registration event message where CRN does not exist in delius`() {
+    val crn = "X123456"
+    val event: HmppsDomainEvent =
+      SqsNotificationGeneratingHelper(zonedCurrentDateTime)
+        .createHmppsDomainEventWithReason(identifiers = "[{\"type\":\"CRN\",\"value\":\"$crn\"}]")
+    domainMessage = objectMapper.readValue(event.message)
+
+    every { domainEventIdentitiesResolver.getHmppsId(any()) } throws NotFoundException("Person with crn $crn not found")
+
+    assertThatThrownBy {
+      strategy.createNotifications(domainMessage, eventType, baseUrl)
+    }.isInstanceOf(NotFoundException::class.java)
+      .hasMessage("Person with crn $crn not found")
+  }
+
+  @Test
+  fun `should create event notification with hmpps id as nomis number when no CRN and cannot find CRN by nomis number`() {
+    val mockNomisId = "MOCK-NOMIS-ID"
+    every { domainEventIdentitiesResolver.getHmppsId(any()) } returns mockNomisId
+    every { domainEventIdentitiesResolver.getPrisonId(any()) } returns null
+
+    val hmppsMessage = """
+      {"eventType":"calculate-release-dates.prisoner.changed","description":"Prisoners release dates have been re-calculated","additionalInformation":{"prisonerId":"$mockNomisId","bookingId":1219387},"version":1,"occurredAt":"2024-08-13T14:15:16.460942253+01:00"}
+    """.trimIndent()
+    val domainEvent = generateHmppsDomainEvent("calculate-release-dates.prisoner.changed", hmppsMessage)
+    domainMessage = objectMapper.readValue(domainEvent.message)
+    eventType = IntegrationEventType.KEY_DATES_AND_ADJUSTMENTS_PRISONER_RELEASE
+
+    val notifications = strategy.createNotifications(domainMessage, eventType, baseUrl)
+
+    assertThat(1).isEqualTo(notifications.size)
+
+    val notification = notifications[0]
+    assertThat(notification)
+      .extracting(
+        EventNotification::eventType,
+        EventNotification::hmppsId,
+        EventNotification::url,
+      ).containsExactly(
+        IntegrationEventType.KEY_DATES_AND_ADJUSTMENTS_PRISONER_RELEASE,
+        mockNomisId,
+        "$baseUrl/v1/persons/$mockNomisId/sentences/latest-key-dates-and-adjustments",
+      )
+    assertThat(notification.lastModifiedDateTime).isAfterOrEqualTo(currentTime)
+  }
+
+  @Test
+  fun `should throw exception for a domain event message with no prisonId which requires a prisonId`() {
+    every { domainEventIdentitiesResolver.getPrisonId(any()) } returns null
+    val event: HmppsDomainEvent =
+      SqsNotificationGeneratingHelper(zonedCurrentDateTime).createHmppsDomainEvent(identifiers = "[{\"type\":\"PNC\",\"value\":\"2018/0123456X\"}]")
+    domainMessage = objectMapper.readValue(event.message)
+    eventType = IntegrationEventType.PRISON_LOCATION_CHANGED
+
+    assertThatThrownBy {
+      strategy.createNotifications(domainMessage, eventType, baseUrl)
+    }.isInstanceOf(NotFoundException::class.java)
+      .hasMessage("Prison ID could not be found in domain event message")
+  }
+
+  @Test
+  fun `should create event notification for a domain registration event message with no CRN or no Nomis Number which doesn't require a hmppsId`() {
+    val event: HmppsDomainEvent =
+      SqsNotificationGeneratingHelper(zonedCurrentDateTime).createHmppsDomainEvent(identifiers = "[{\"type\":\"PNC\",\"value\":\"2018/0123456X\"}]")
+    domainMessage = objectMapper.readValue(event.message)
+    eventType = IntegrationEventType.PRISONERS_CHANGED
+
+    assertDoesNotThrow {
+      val createNotifications = strategy.createNotifications(domainMessage, eventType, baseUrl)
+      createNotifications
+      assertThat(createNotifications).hasSize(1)
+    }
+  }
+
+  @Test
+  fun `will process and save a prisoner released domain event message for event with message with reason is RELEASED`() {
+    val mockNomisId = "MOCK-NOMIS-ID"
+    val mockCrn = "mockCrn"
+    val event: HmppsDomainEvent =
+      SqsNotificationGeneratingHelper(zonedCurrentDateTime).createHmppsDomainEventWithReason(
+        eventType = "prison-offender-events.prisoner.released",
+        reason = "RELEASED",
+        identifiers = "[{\"type\":\"nomsNumber\",\"value\":\"$mockNomisId\"}]",
+      )
+    domainMessage = objectMapper.readValue(event.message)
+    eventType = IntegrationEventType.KEY_DATES_AND_ADJUSTMENTS_PRISONER_RELEASE
+
+    every { domainEventIdentitiesResolver.getHmppsId(any()) } returns mockCrn
+
+    val notifications = strategy.createNotifications(domainMessage, eventType, baseUrl)
+
+    assertThat(1).isEqualTo(notifications.size)
+
+    assertThat(notifications[0])
+      .extracting(
+        EventNotification::eventType,
+        EventNotification::hmppsId,
+        EventNotification::url,
+      ).containsExactly(
+        IntegrationEventType.KEY_DATES_AND_ADJUSTMENTS_PRISONER_RELEASE,
+        mockCrn,
+        "$baseUrl/v1/persons/$mockCrn/sentences/latest-key-dates-and-adjustments",
+      )
+    assertThat(notifications[0].lastModifiedDateTime).isAfterOrEqualTo(currentTime)
+  }
+
+  @Test
+  fun `will process and save a prisoner released domain event message for event with message event type of CALCULATED_RELEASE_DATES_PRISONER_CHANGED`() {
+    val mockNomisId = "MOCK-NOMIS-ID"
+    val mockCrn = "mockCrn"
+    val hmppsMessage = """
+      {"eventType":"calculate-release-dates.prisoner.changed","description":"Prisoners release dates have been re-calculated","additionalInformation":{"prisonerId":"$mockNomisId","bookingId":1219387},"version":1,"occurredAt":"2024-08-13T14:15:16.460942253+01:00"}
+    """.trimIndent()
+
+    val event = generateHmppsDomainEvent("calculate-release-dates.prisoner.changed", hmppsMessage)
+    domainMessage = objectMapper.readValue(event.message)
+    eventType = IntegrationEventType.KEY_DATES_AND_ADJUSTMENTS_PRISONER_RELEASE
+
+    every { domainEventIdentitiesResolver.getHmppsId(any()) } returns mockCrn
+
+    val notifications = strategy.createNotifications(domainMessage, eventType, baseUrl)
+
+    assertThat(1).isEqualTo(notifications.size)
+    assertThat(notifications[0])
+      .extracting(
+        EventNotification::eventType,
+        EventNotification::hmppsId,
+        EventNotification::url,
+      ).containsExactly(
+        IntegrationEventType.KEY_DATES_AND_ADJUSTMENTS_PRISONER_RELEASE,
+        mockCrn,
+        "$baseUrl/v1/persons/$mockCrn/sentences/latest-key-dates-and-adjustments",
+      )
+    assertThat(notifications[0].lastModifiedDateTime).isAfterOrEqualTo(currentTime)
+  }
+
+  @Test
+  fun `will process and save event message with no CRN and cannot find CRN by nomis number`() {
+    val mockNomisId = "MOCK-NOMIS-ID"
+    every { domainEventIdentitiesResolver.getHmppsId(any()) } returns mockNomisId
+
+    val hmppsMessage = """
+      {"eventType":"calculate-release-dates.prisoner.changed","description":"Prisoners release dates have been re-calculated","additionalInformation":{"prisonerId":"$mockNomisId","bookingId":1219387},"version":1,"occurredAt":"2024-08-13T14:15:16.460942253+01:00"}
+    """.trimIndent()
+
+    val event = generateHmppsDomainEvent("calculate-release-dates.prisoner.changed", hmppsMessage)
+    domainMessage = objectMapper.readValue(event.message)
+    eventType = IntegrationEventType.KEY_DATES_AND_ADJUSTMENTS_PRISONER_RELEASE
+
+    val notifications = strategy.createNotifications(domainMessage, eventType, baseUrl)
+
+    assertThat(1).isEqualTo(notifications.size)
+    assertThat(notifications[0])
+      .extracting(
+        EventNotification::eventType,
+        EventNotification::hmppsId,
+        EventNotification::url,
+      ).containsExactly(
+        IntegrationEventType.KEY_DATES_AND_ADJUSTMENTS_PRISONER_RELEASE,
+        mockNomisId,
+        "$baseUrl/v1/persons/$mockNomisId/sentences/latest-key-dates-and-adjustments",
+      )
+    assertThat(notifications[0].lastModifiedDateTime).isAfterOrEqualTo(currentTime)
+  }
+
+  companion object {
+    @JvmStatic
+    fun eventTypeAndIntegrationEventTypeProvider() = Stream.of(
+      Arguments.of("probation-case.engagement.created", PROBATION_CASE_ENGAGEMENT_CREATED_MESSAGE),
+      Arguments.of("probation-case.prison-identifier.added", PROBATION_CASE_PRISON_IDENTIFIER_ADDED),
+      Arguments.of("prisoner-offender-search.prisoner.created", PRISONER_OFFENDER_SEARCH_PRISONER_CREATED),
+      Arguments.of("prisoner-offender-search.prisoner.updated", PRISONER_OFFENDER_SEARCH_PRISONER_UPDATED),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/DomainEventIdentitiesResolverTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/DomainEventIdentitiesResolverTest.kt
@@ -1,0 +1,79 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationevents.services
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.exceptions.NotFoundException
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.gateway.ProbationIntegrationApiGateway
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents.generateHmppsDomainEvent
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.SqsNotificationGeneratingHelper
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.HmppsDomainEvent
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.PersonExists
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.PersonIdentifier
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+class DomainEventIdentitiesResolverTest {
+  private val objectMapper = ObjectMapper()
+  private val currentTime: LocalDateTime = LocalDateTime.now()
+  private val zonedCurrentDateTime = currentTime.atZone(ZoneId.systemDefault())
+
+  private val getPrisonIdService = mockk<GetPrisonIdService>()
+  private val probationIntegrationApiGateway = mockk<ProbationIntegrationApiGateway>()
+
+  private lateinit var resolver: DomainEventIdentitiesResolver
+
+  @BeforeEach
+  fun setUp() {
+    resolver = DomainEventIdentitiesResolver(probationIntegrationApiGateway, getPrisonIdService)
+  }
+
+  @Test
+  fun `should throw exception for a domain registration event message where CRN does not exist in delius`() {
+    val crn = "X123456"
+    val domainEvent: HmppsDomainEvent =
+      SqsNotificationGeneratingHelper(zonedCurrentDateTime).createHmppsDomainEventWithReason(identifiers = "[{\"type\":\"CRN\",\"value\":\"$crn\"}]")
+    every { probationIntegrationApiGateway.getPersonExists(crn) } returns PersonExists(crn, false)
+
+    val exception = assertThrows<NotFoundException> {
+      resolver.getHmppsId(objectMapper.readValue(domainEvent.message))
+    }
+
+    assertThat(exception.message).isEqualTo("Person with crn $crn not found")
+  }
+
+  @Test
+  fun `should return crn for domain event when both noms id and crn found for prisoner`() {
+    val mockNomisId = "MOCK-NOMIS-ID"
+    val crn = "X123456"
+    val hmppsMessage = """
+      {"eventType":"calculate-release-dates.prisoner.changed","description":"Prisoners release dates have been re-calculated","additionalInformation":{"prisonerId":"$mockNomisId","bookingId":1219387},"version":1,"occurredAt":"2024-08-13T14:15:16.460942253+01:00"}
+    """.trimIndent()
+    val domainEvent = generateHmppsDomainEvent("calculate-release-dates.prisoner.changed", hmppsMessage)
+    every { probationIntegrationApiGateway.getPersonIdentifier(mockNomisId) } returns PersonIdentifier(crn, mockNomisId)
+
+    val hmppsId = resolver.getHmppsId(objectMapper.readValue(domainEvent.message))
+
+    assertThat(hmppsId).isEqualTo(crn)
+  }
+
+  @Test
+  fun `should return nomsId for domain event with no crn and no crn found for prisoner`() {
+    val mockNomisId = "MOCK-NOMIS-ID"
+    val hmppsMessage = """
+      {"eventType":"calculate-release-dates.prisoner.changed","description":"Prisoners release dates have been re-calculated","additionalInformation":{"prisonerId":"$mockNomisId","bookingId":1219387},"version":1,"occurredAt":"2024-08-13T14:15:16.460942253+01:00"}
+    """.trimIndent()
+    val domainEvent = generateHmppsDomainEvent("calculate-release-dates.prisoner.changed", hmppsMessage)
+
+    every { probationIntegrationApiGateway.getPersonIdentifier(mockNomisId) } returns null
+
+    val hmppsId = resolver.getHmppsId(objectMapper.readValue(domainEvent.message))
+
+    assertThat(hmppsId).isEqualTo(mockNomisId)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/HmppsDomainEventServiceLicenceConditionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/HmppsDomainEventServiceLicenceConditionTest.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationevents.gateway.ProbationInte
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents.generateHmppsDomainEvent
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.PersonExists
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventType
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.registration.HmppsDomainEventMessage
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.repository.EventNotificationRepository
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.repository.model.data.EventNotification
 import java.time.LocalDateTime
@@ -27,7 +28,15 @@ class HmppsDomainEventServiceLicenceConditionTest {
   private val deadLetterQueueService = mockk<DeadLetterQueueService>()
   private val probationIntegrationApiGateway = mockk<ProbationIntegrationApiGateway>()
   private val getPrisonIdService = mockk<GetPrisonIdService>()
-  private val hmppsDomainEventService: HmppsDomainEventService = HmppsDomainEventService(eventNotificationRepository, deadLetterQueueService, probationIntegrationApiGateway, getPrisonIdService, baseUrl)
+  private val integrationEventCreationStrategyProvider = mockk<IntegrationEventCreationStrategyProvider>()
+  private val defaultEventCreationStrategy = mockk<DefaultEventCreationStrategy>()
+
+  private val hmppsDomainEventService: HmppsDomainEventService = HmppsDomainEventService(
+    eventNotificationRepository,
+    deadLetterQueueService,
+    integrationEventCreationStrategyProvider,
+    baseUrl,
+  )
   private val currentTime: LocalDateTime = LocalDateTime.now()
   private val crn = "X777776"
   private val nomsNumber = "A1234BC"
@@ -41,6 +50,24 @@ class HmppsDomainEventServiceLicenceConditionTest {
     every { eventNotificationRepository.insertOrUpdate(any()) } returnsArgument 0
 
     every { getPrisonIdService.execute(nomsNumber) } returns null
+    every { integrationEventCreationStrategyProvider.forEventType(any()) } returns defaultEventCreationStrategy
+
+    every { defaultEventCreationStrategy.createNotifications(any(), any(), any()) } answers {
+      val hmppsDomainEventMessage = arg<HmppsDomainEventMessage>(0)
+      val integrationEventType = arg<IntegrationEventType>(1)
+      val baseUrl = arg<String>(2)
+
+      val additionalInfo = hmppsDomainEventMessage.additionalInformation
+
+      listOf(
+        EventNotification(
+          eventType = integrationEventType,
+          hmppsId = crn,
+          url = "$baseUrl/${integrationEventType.path(crn, null, additionalInfo)}",
+          lastModifiedDateTime = LocalDateTime.now(),
+        ),
+      )
+    }
   }
 
   @ParameterizedTest

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/HmppsDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/HmppsDomainEventServiceTest.kt
@@ -1,29 +1,29 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationevents.services
 
-import io.mockk.Called
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.verify
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
-import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.context.annotation.Configuration
 import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.exceptions.NotFoundException
-import uk.gov.justice.digital.hmpps.hmppsintegrationevents.gateway.ProbationIntegrationApiGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents.PRISONER_OFFENDER_SEARCH_PRISONER_CREATED
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents.PRISONER_OFFENDER_SEARCH_PRISONER_UPDATED
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents.PROBATION_CASE_ENGAGEMENT_CREATED_MESSAGE
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents.PROBATION_CASE_PRISON_IDENTIFIER_ADDED
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents.generateHmppsDomainEvent
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.SqsNotificationGeneratingHelper
-import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.PersonExists
-import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.PersonIdentifier
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.HmppsDomainEvent
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventType
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.registration.HmppsDomainEventMessage
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.repository.EventNotificationRepository
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.repository.model.data.EventNotification
 import java.time.LocalDateTime
@@ -33,17 +33,24 @@ import java.time.ZoneId
 @ActiveProfiles("test")
 class HmppsDomainEventServiceTest {
 
+  private val hmppsId = "X777776"
+  private val prisonId = "MDI"
   private final val baseUrl = "https://dev.integration-api.hmpps.service.justice.gov.uk"
+  private final val objectMapper = ObjectMapper()
 
   private val eventNotificationRepository = mockk<EventNotificationRepository>()
   private val deadLetterQueueService = mockk<DeadLetterQueueService>()
-  private val probationIntegrationApiGateway = mockk<ProbationIntegrationApiGateway>()
-  private val getPrisonIdService = mockk<GetPrisonIdService>()
-  private val hmppsDomainEventService: HmppsDomainEventService = HmppsDomainEventService(eventNotificationRepository, deadLetterQueueService, probationIntegrationApiGateway, getPrisonIdService, baseUrl)
+  private val integrationEventCreationStrategyProvider = mockk<IntegrationEventCreationStrategyProvider>()
+  private val defaultEventCreationStrategy = mockk<DefaultEventCreationStrategy>()
+  private val hmppsDomainEventService: HmppsDomainEventService = HmppsDomainEventService(
+    eventNotificationRepository,
+    deadLetterQueueService,
+    integrationEventCreationStrategyProvider,
+    baseUrl,
+  )
   private val currentTime: LocalDateTime = LocalDateTime.now()
   private val zonedCurrentDateTime = currentTime.atZone(ZoneId.systemDefault())
   private val mockNomisId = "mockNomisId"
-  private val mockCrn = "mockCrn"
 
   @BeforeEach
   fun setup() {
@@ -53,25 +60,62 @@ class HmppsDomainEventServiceTest {
     every { eventNotificationRepository.updateLastModifiedDateTimeByHmppsIdAndEventType(any(), any(), any()) } returns 1
     every { eventNotificationRepository.insertOrUpdate(any()) } returnsArgument 0
     every { deadLetterQueueService.sendEvent(any(), any()) } returnsArgument 0
+    every { integrationEventCreationStrategyProvider.forEventType(any()) } returns defaultEventCreationStrategy
 
-    every { probationIntegrationApiGateway.getPersonIdentifier(mockNomisId) } returns PersonIdentifier(mockCrn, mockNomisId)
-    every { probationIntegrationApiGateway.getPersonExists("X777776") } returns PersonExists("X777776", true)
+    every { defaultEventCreationStrategy.createNotifications(any(), any(), any()) } answers {
+      val hmppsDomainEventMessage = arg<HmppsDomainEventMessage>(0)
+      val integrationEventType = arg<IntegrationEventType>(1)
+      val baseUrl = arg<String>(2)
 
-    every { getPrisonIdService.execute(mockNomisId) } returns null
-    every { getPrisonIdService.execute("A1234BC") } returns null
+      val additionalInfo = hmppsDomainEventMessage.additionalInformation
+
+      listOf(
+        EventNotification(
+          eventType = integrationEventType,
+          hmppsId = hmppsId,
+          url = "$baseUrl/${integrationEventType.path(hmppsId, prisonId, additionalInfo)}",
+          lastModifiedDateTime = LocalDateTime.now(),
+        ),
+      )
+    }
   }
 
-  @Test
-  fun `process and save probation status changed event`() {
-    val event = SqsNotificationGeneratingHelper(zonedCurrentDateTime)
-      .createHmppsDomainEvent("probation-case.registration.added", "ASFO")
-    hmppsDomainEventService.execute(event, listOf(IntegrationEventType.PROBATION_STATUS_CHANGED))
+  @ParameterizedTest
+  @CsvSource(
+    "probation-case.registration.added, ASFO, PROBATION_STATUS_CHANGED, status-information",
+    "probation-case.registration.added, RCCO, DYNAMIC_RISKS_CHANGED, risks/dynamic",
+  )
+  fun `will process and save a person status event`(
+    eventType: String,
+    registerTypeCode: String,
+    integrationEvent: String,
+    path: String,
+  ) {
+    val event: HmppsDomainEvent =
+      SqsNotificationGeneratingHelper(zonedCurrentDateTime).createHmppsDomainEvent(eventType, registerTypeCode)
+
+    hmppsDomainEventService.execute(event, listOf(IntegrationEventType.valueOf(integrationEvent)))
+
+    verify(exactly = 1) {
+      integrationEventCreationStrategyProvider.forEventType(
+        IntegrationEventType.valueOf(
+          integrationEvent,
+        ),
+      )
+    }
+    verify(exactly = 1) {
+      defaultEventCreationStrategy.createNotifications(
+        objectMapper.readValue(event.message),
+        IntegrationEventType.valueOf(integrationEvent),
+        baseUrl,
+      )
+    }
     verify(exactly = 1) {
       eventNotificationRepository.insertOrUpdate(
         EventNotification(
-          eventType = IntegrationEventType.PROBATION_STATUS_CHANGED,
-          hmppsId = "X777776",
-          url = "$baseUrl/v1/persons/X777776/status-information",
+          eventType = IntegrationEventType.valueOf(integrationEvent),
+          hmppsId = hmppsId,
+          url = "$baseUrl/v1/persons/$hmppsId/$path",
           lastModifiedDateTime = currentTime,
         ),
       )
@@ -103,8 +147,8 @@ class HmppsDomainEventServiceTest {
       eventNotificationRepository.insertOrUpdate(
         EventNotification(
           eventType = IntegrationEventType.MAPPA_DETAIL_CHANGED,
-          hmppsId = "X777776",
-          url = "$baseUrl/v1/persons/X777776/risks/mappadetail",
+          hmppsId = hmppsId,
+          url = "$baseUrl/v1/persons/$hmppsId/risks/mappadetail",
           lastModifiedDateTime = currentTime,
         ),
       )
@@ -112,26 +156,10 @@ class HmppsDomainEventServiceTest {
   }
 
   @Test
-  fun `will not process and save a domain registration event message with no CRN or no Nomis Number which requires a hmppsId`() {
-    val event = SqsNotificationGeneratingHelper(zonedCurrentDateTime)
-      .createHmppsDomainEvent(identifiers = "[{\"type\":\"PNC\",\"value\":\"2018/0123456X\"}]")
-    val exception = assertThrows<NotFoundException> { hmppsDomainEventService.execute(event, listOf(IntegrationEventType.MAPPA_DETAIL_CHANGED)) }
-    verify { eventNotificationRepository wasNot Called }
-    assertThat(exception.message, equalTo("Identifier could not be found in domain event message"))
-  }
-
-  @Test
-  fun `process and save domain registration event message with no CRN or no Nomis Number which doesn't require a hmppsId`() {
-    val event = SqsNotificationGeneratingHelper(zonedCurrentDateTime)
-      .createHmppsDomainEvent(identifiers = "[{\"type\":\"PNC\",\"value\":\"2018/0123456X\"}]")
-    assertDoesNotThrow { hmppsDomainEventService.execute(event, listOf(IntegrationEventType.PRISONERS_CHANGED)) }
-    verify(exactly = 1) { eventNotificationRepository.insertOrUpdate(any()) }
-  }
-
-  @Test
   fun `process and save risk assessment scores rsr determined event`() {
-    val event = SqsNotificationGeneratingHelper(zonedCurrentDateTime)
-      .createHmppsDomainEvent(eventType = "risk-assessment.scores.rsr.determined")
+    val event =
+      SqsNotificationGeneratingHelper(zonedCurrentDateTime)
+        .createHmppsDomainEvent(eventType = "risk-assessment.scores.rsr.determined")
     hmppsDomainEventService.execute(event, listOf(IntegrationEventType.RISK_SCORE_CHANGED))
     verify(exactly = 1) {
       eventNotificationRepository.insertOrUpdate(
@@ -171,94 +199,109 @@ class HmppsDomainEventServiceTest {
       eventNotificationRepository.insertOrUpdate(
         EventNotification(
           eventType = IntegrationEventType.RISK_SCORE_CHANGED,
-          hmppsId = "X777776",
-          url = "$baseUrl/v1/persons/X777776/risks/scores",
+          hmppsId = hmppsId,
+          url = "$baseUrl/v1/persons/$hmppsId/risks/scores",
           lastModifiedDateTime = currentTime,
         ),
       )
     }
-  }
-
-  @Test
-  fun `will not process and save a domain event message with no prisonId which requires a prisonId`() {
-    val event = SqsNotificationGeneratingHelper(zonedCurrentDateTime)
-      .createHmppsDomainEvent(identifiers = "[{\"type\":\"PNC\",\"value\":\"2018/0123456X\"}]")
-    val exception = assertThrows<NotFoundException> { hmppsDomainEventService.execute(event, listOf(IntegrationEventType.PRISON_LOCATION_CHANGED)) }
-    verify { eventNotificationRepository wasNot Called }
-    assertThat(exception.message, equalTo("Prison ID could not be found in domain event message"))
   }
 
   @Test
   fun `will use prisonId if found on the domain event`() {
     val prisonId = "MDI"
-    val event = SqsNotificationGeneratingHelper(zonedCurrentDateTime)
-      .createHmppsDomainEventWithPrisonId(eventType = "assessment.summary.produced", prisonId = prisonId)
+    val event =
+      SqsNotificationGeneratingHelper(zonedCurrentDateTime).createHmppsDomainEventWithPrisonId(
+        eventType = "assessment.summary.produced",
+        prisonId = prisonId,
+      )
+    mockStrategy(prisonId, hmppsId)
     hmppsDomainEventService.execute(event, listOf(IntegrationEventType.RISK_SCORE_CHANGED))
     verify(exactly = 1) {
       eventNotificationRepository.insertOrUpdate(
         EventNotification(
           eventType = IntegrationEventType.RISK_SCORE_CHANGED,
-          hmppsId = "X777776",
+          hmppsId = hmppsId,
           prisonId = prisonId,
-          url = "$baseUrl/v1/persons/X777776/risks/scores",
+          url = "$baseUrl/v1/persons/$hmppsId/risks/scores",
           lastModifiedDateTime = currentTime,
         ),
       )
     }
-    verify(exactly = 0) { getPrisonIdService.execute(any()) }
-    verify(exactly = 0) { eventNotificationRepository.updateLastModifiedDateTimeByHmppsIdAndEventType(currentTime, "X777776", IntegrationEventType.RISK_SCORE_CHANGED) }
+    verify(exactly = 0) {
+      eventNotificationRepository.updateLastModifiedDateTimeByHmppsIdAndEventType(
+        currentTime,
+        hmppsId,
+        IntegrationEventType.RISK_SCORE_CHANGED,
+      )
+    }
   }
 
   @Test
   fun `will get the prison ID from the getPrisonIdService`() {
     val prisonId = "MDI"
-    every { getPrisonIdService.execute("A1234BC") } returns prisonId
-    val event = SqsNotificationGeneratingHelper(zonedCurrentDateTime)
-      .createHmppsDomainEvent(eventType = "assessment.summary.produced")
+    val hmppsId = hmppsId
+    mockStrategy(prisonId, hmppsId)
+    val event =
+      SqsNotificationGeneratingHelper(zonedCurrentDateTime)
+        .createHmppsDomainEvent(eventType = "assessment.summary.produced")
     hmppsDomainEventService.execute(event, listOf(IntegrationEventType.RISK_SCORE_CHANGED))
     verify(exactly = 1) {
       eventNotificationRepository.insertOrUpdate(
         EventNotification(
           eventType = IntegrationEventType.RISK_SCORE_CHANGED,
-          hmppsId = "X777776",
+          hmppsId = hmppsId,
           prisonId = prisonId,
-          url = "$baseUrl/v1/persons/X777776/risks/scores",
+          url = "$baseUrl/v1/persons/$hmppsId/risks/scores",
           lastModifiedDateTime = currentTime,
         ),
       )
     }
-    verify(exactly = 0) { eventNotificationRepository.updateLastModifiedDateTimeByHmppsIdAndEventType(currentTime, "X777776", IntegrationEventType.RISK_SCORE_CHANGED) }
+    verify(exactly = 0) {
+      eventNotificationRepository.updateLastModifiedDateTimeByHmppsIdAndEventType(
+        currentTime,
+        hmppsId,
+        IntegrationEventType.RISK_SCORE_CHANGED,
+      )
+    }
   }
 
   @Test
-  fun `process and save event message with no CRN and cannot find CRN by nomis number`() {
-    every { probationIntegrationApiGateway.getPersonIdentifier(mockNomisId) } returns null
-    val hmppsMessage = """
-      {"eventType":"calculate-release-dates.prisoner.changed","description":"Prisoners release dates have been re-calculated","additionalInformation":{"prisonerId":"$mockNomisId","bookingId":1219387},"version":1,"occurredAt":"2024-08-13T14:15:16.460942253+01:00"}
-    """.trimIndent()
-    val event = generateHmppsDomainEvent("calculate-release-dates.prisoner.changed", hmppsMessage)
-    hmppsDomainEventService.execute(event, listOf(IntegrationEventType.KEY_DATES_AND_ADJUSTMENTS_PRISONER_RELEASE))
-    verify(exactly = 1) {
-      eventNotificationRepository.insertOrUpdate(
+  fun `should throw exception when hmpps id not found`() {
+    val crn = "NOT_FOUND_CRN"
+    every {
+      defaultEventCreationStrategy.createNotifications(
+        any(),
+        any(),
+        any(),
+      )
+    } throws NotFoundException("Person with crn $crn not found")
+
+    val event: HmppsDomainEvent =
+      SqsNotificationGeneratingHelper(zonedCurrentDateTime).createHmppsDomainEvent(eventType = "assessment.summary.produced")
+
+    assertThatThrownBy {
+      hmppsDomainEventService.execute(event, listOf(IntegrationEventType.RISK_SCORE_CHANGED))
+    }.isInstanceOf(NotFoundException::class.java)
+      .hasMessage("Person with crn $crn not found")
+  }
+
+  private fun mockStrategy(prisonId: String? = null, hmppsId: String) {
+    every { defaultEventCreationStrategy.createNotifications(any(), any(), any()) } answers {
+      val hmppsDomainEventMessage = arg<HmppsDomainEventMessage>(0)
+      val integrationEventType = arg<IntegrationEventType>(1)
+      val baseUrl = arg<String>(2)
+      val additionalInfo = hmppsDomainEventMessage.additionalInformation
+      listOf(
         EventNotification(
-          eventType = IntegrationEventType.KEY_DATES_AND_ADJUSTMENTS_PRISONER_RELEASE,
-          hmppsId = mockNomisId,
-          url = "$baseUrl/v1/persons/$mockNomisId/sentences/latest-key-dates-and-adjustments",
-          lastModifiedDateTime = currentTime,
+          eventType = integrationEventType,
+          hmppsId = hmppsId,
+          prisonId = prisonId,
+          url = "$baseUrl/${integrationEventType.path(hmppsId, prisonId, additionalInfo)}",
+          lastModifiedDateTime = LocalDateTime.now(),
         ),
       )
     }
-  }
-
-  @Test
-  fun `will not process and save a domain registration event message where CRN does not exist in delius`() {
-    val crn = "X123456"
-    val event = SqsNotificationGeneratingHelper(zonedCurrentDateTime)
-      .createHmppsDomainEventWithReason(identifiers = "[{\"type\":\"CRN\",\"value\":\"$crn\"}]")
-    every { probationIntegrationApiGateway.getPersonExists("X123456") } returns PersonExists(crn, false)
-    val exception = assertThrows<NotFoundException> { hmppsDomainEventService.execute(event, listOf(IntegrationEventType.MAPPA_DETAIL_CHANGED)) }
-    verify { eventNotificationRepository wasNot Called }
-    assertThat(exception.message, equalTo("Person with crn $crn not found"))
   }
 
   @Test
@@ -267,170 +310,75 @@ class HmppsDomainEventServiceTest {
       {"eventType":"calculate-release-dates.prisoner.changed","description":"Prisoners release dates have been re-calculated","additionalInformation":{"prisonerId":"$mockNomisId","bookingId":1219387},"version":1,"occurredAt":"2024-08-13T14:15:16.460942253+01:00"}
     """.trimIndent()
     val event = generateHmppsDomainEvent("calculate-release-dates.prisoner.changed", hmppsMessage)
+
     hmppsDomainEventService.execute(event, listOf(IntegrationEventType.KEY_DATES_AND_ADJUSTMENTS_PRISONER_RELEASE))
+
     verify(exactly = 1) {
       eventNotificationRepository.insertOrUpdate(
         EventNotification(
           eventType = IntegrationEventType.KEY_DATES_AND_ADJUSTMENTS_PRISONER_RELEASE,
-          hmppsId = mockCrn,
-          url = "$baseUrl/v1/persons/$mockCrn/sentences/latest-key-dates-and-adjustments",
+          hmppsId = hmppsId,
+          url = "$baseUrl/v1/persons/$hmppsId/sentences/latest-key-dates-and-adjustments",
           lastModifiedDateTime = currentTime,
         ),
       )
     }
   }
 
-  @Test
-  fun `process and save prisoner released domain event message for event with message with reason is RELEASED`() {
-    val event = SqsNotificationGeneratingHelper(zonedCurrentDateTime)
-      .createHmppsDomainEventWithReason(eventType = "prison-offender-events.prisoner.released", reason = "RELEASED", identifiers = "[{\"type\":\"nomsNumber\",\"value\":\"$mockNomisId\"}]")
-    hmppsDomainEventService.execute(event, listOf(IntegrationEventType.KEY_DATES_AND_ADJUSTMENTS_PRISONER_RELEASE))
-    verify(exactly = 1) {
-      eventNotificationRepository.insertOrUpdate(
-        EventNotification(
-          eventType = IntegrationEventType.KEY_DATES_AND_ADJUSTMENTS_PRISONER_RELEASE,
-          hmppsId = mockCrn,
-          url = "$baseUrl/v1/persons/$mockCrn/sentences/latest-key-dates-and-adjustments",
-          lastModifiedDateTime = currentTime,
-        ),
-      )
+  @ParameterizedTest
+  @ValueSource(
+    strings = [
+      "probation-case.engagement.created",
+      "probation-case.prison-identifier.added",
+      "prisoner-offender-search.prisoner.created",
+      "prisoner-offender-search.prisoner.updated",
+    ],
+  )
+  fun `process event processing for api persons {hmppsId} `(eventType: String) {
+    val message = when (eventType) {
+      "probation-case.engagement.created" -> PROBATION_CASE_ENGAGEMENT_CREATED_MESSAGE
+      "probation-case.prison-identifier.added" -> PROBATION_CASE_PRISON_IDENTIFIER_ADDED
+      "prisoner-offender-search.prisoner.created" -> PRISONER_OFFENDER_SEARCH_PRISONER_CREATED
+      "prisoner-offender-search.prisoner.updated" -> PRISONER_OFFENDER_SEARCH_PRISONER_UPDATED
+      else -> throw RuntimeException("Unexpected event type: $eventType")
     }
-  }
 
-  @Test
-  fun `process probation case engagement created event`() {
-    val eventType = "probation-case.engagement.created"
-    val message = PROBATION_CASE_ENGAGEMENT_CREATED_MESSAGE.replace("\\", "")
-    val event = generateHmppsDomainEvent(eventType, message)
-    every { probationIntegrationApiGateway.getPersonIdentifier("A1234BC") } returns PersonIdentifier("X777776", "A1234BC")
-    every { getPrisonIdService.execute("A1234BC") } returns null
+    val hmppsMessage = message.replace("\\", "")
+    val event = generateHmppsDomainEvent(eventType, hmppsMessage)
+
     hmppsDomainEventService.execute(event, listOf(IntegrationEventType.PERSON_STATUS_CHANGED))
+
     verify(exactly = 1) {
       eventNotificationRepository.insertOrUpdate(
         EventNotification(
           eventType = IntegrationEventType.PERSON_STATUS_CHANGED,
-          hmppsId = "X777776",
-          url = "$baseUrl/v1/persons/X777776",
+          hmppsId = hmppsId,
+          url = "$baseUrl/v1/persons/$hmppsId",
           lastModifiedDateTime = currentTime,
         ),
       )
     }
   }
 
-  @Test
-  fun `process probation case prison identifier added event`() {
-    val eventType = "probation-case.prison-identifier.added"
-    val message = PROBATION_CASE_PRISON_IDENTIFIER_ADDED.replace("\\", "")
-    val event = generateHmppsDomainEvent(eventType, message)
-    every { probationIntegrationApiGateway.getPersonIdentifier("A1234BC") } returns PersonIdentifier("X777776", "A1234BC")
-    every { getPrisonIdService.execute("A1234BC") } returns null
-    hmppsDomainEventService.execute(event, listOf(IntegrationEventType.PERSON_STATUS_CHANGED))
-    verify(exactly = 1) {
-      eventNotificationRepository.insertOrUpdate(
-        EventNotification(
-          eventType = IntegrationEventType.PERSON_STATUS_CHANGED,
-          hmppsId = "X777776",
-          url = "$baseUrl/v1/persons/X777776",
-          lastModifiedDateTime = currentTime,
-        ),
-      )
-    }
-  }
-
-  @Test
-  fun `process prisoner offender search prisoner created event`() {
-    val eventType = "prisoner-offender-search.prisoner.created"
-    val message = PRISONER_OFFENDER_SEARCH_PRISONER_CREATED.replace("\\", "")
-    val event = generateHmppsDomainEvent(eventType, message)
-    every { probationIntegrationApiGateway.getPersonIdentifier("A1234BC") } returns PersonIdentifier("X777776", "A1234BC")
-    every { getPrisonIdService.execute("A1234BC") } returns null
-    hmppsDomainEventService.execute(event, listOf(IntegrationEventType.PERSON_STATUS_CHANGED))
-    verify(exactly = 1) {
-      eventNotificationRepository.insertOrUpdate(
-        EventNotification(
-          eventType = IntegrationEventType.PERSON_STATUS_CHANGED,
-          hmppsId = "X777776",
-          url = "$baseUrl/v1/persons/X777776",
-          lastModifiedDateTime = currentTime,
-        ),
-      )
-    }
-  }
-
-  @Test
-  fun `process prisoner offender search prisoner updated event`() {
-    val eventType = "prisoner-offender-search.prisoner.updated"
-    val message = PRISONER_OFFENDER_SEARCH_PRISONER_UPDATED.replace("\\", "")
-    val event = generateHmppsDomainEvent(eventType, message)
-    every { probationIntegrationApiGateway.getPersonIdentifier("A1234BC") } returns PersonIdentifier("X777776", "A1234BC")
-    every { getPrisonIdService.execute("A1234BC") } returns null
-    hmppsDomainEventService.execute(event, listOf(IntegrationEventType.PERSON_STATUS_CHANGED))
-    verify(exactly = 1) {
-      eventNotificationRepository.insertOrUpdate(
-        EventNotification(
-          eventType = IntegrationEventType.PERSON_STATUS_CHANGED,
-          hmppsId = "X777776",
-          url = "$baseUrl/v1/persons/X777776",
-          lastModifiedDateTime = currentTime,
-        ),
-      )
-    }
-  }
-
-  @Test
-  fun `process person alert changed event`() {
-    val eventType = "person.alert.changed"
+  @ParameterizedTest
+  @ValueSource(
+    strings = [
+      "person.alert.changed",
+      "person.alert.deleted",
+      "person.alert.updated",
+      "person.alert.updated",
+    ],
+  )
+  fun `process person alert changed event`(eventType: String) {
     val message = """
       {"eventType":"$eventType","additionalInformation":{"alertUuid":"8339dd96-4a02-4d5b-bc78-4eda22f678fa","alertCode":"BECTER","source":"NOMIS"},"version":1,"description":"An alert has been created in the alerts service","occurredAt":"2024-08-12T19:48:12.771347283+01:00","detailUrl":"https://alerts-api.hmpps.service.justice.gov.uk/alerts/8339dd96-4a02-4d5b-bc78-4eda22f678fa","personReference":{"identifiers":[{"type":"NOMS","value":"A1234BC"}]}}
     """.trimIndent()
     val event = generateHmppsDomainEvent(eventType, message)
-    every { probationIntegrationApiGateway.getPersonIdentifier("A1234BC") } returns PersonIdentifier("X777776", "A1234BC")
-    every { getPrisonIdService.execute("A1234BC") } returns null
-    hmppsDomainEventService.execute(event, listOf(IntegrationEventType.PERSON_PND_ALERTS_CHANGED))
-    verify(exactly = 1) {
-      eventNotificationRepository.insertOrUpdate(
-        EventNotification(
-          eventType = IntegrationEventType.PERSON_PND_ALERTS_CHANGED,
-          hmppsId = "X777776",
-          url = "$baseUrl/v1/pnd/persons/X777776/alerts",
-          lastModifiedDateTime = currentTime,
-        ),
-      )
-    }
-  }
 
-  @Test
-  fun `process person alert deleted event`() {
-    val eventType = "person.alert.deleted"
-    val message = """
-      {"eventType":"$eventType","additionalInformation":{"alertUuid":"8339dd96-4a02-4d5b-bc78-4eda22f678fa","alertCode":"BECTER","source":"NOMIS"},"version":1,"description":"An alert has been created in the alerts service","occurredAt":"2024-08-12T19:48:12.771347283+01:00","detailUrl":"https://alerts-api.hmpps.service.justice.gov.uk/alerts/8339dd96-4a02-4d5b-bc78-4eda22f678fa","personReference":{"identifiers":[{"type":"NOMS","value":"A1234BC"}]}}
-    """.trimIndent()
-    val event = generateHmppsDomainEvent(eventType, message)
-    every { probationIntegrationApiGateway.getPersonIdentifier("A1234BC") } returns PersonIdentifier("X777776", "A1234BC")
-    every { getPrisonIdService.execute("A1234BC") } returns null
-    hmppsDomainEventService.execute(event, listOf(IntegrationEventType.PERSON_PND_ALERTS_CHANGED))
-    verify(exactly = 1) {
-      eventNotificationRepository.insertOrUpdate(
-        EventNotification(
-          eventType = IntegrationEventType.PERSON_PND_ALERTS_CHANGED,
-          hmppsId = "X777776",
-          url = "$baseUrl/v1/pnd/persons/X777776/alerts",
-          lastModifiedDateTime = currentTime,
-        ),
-      )
-    }
-  }
+    mockStrategy(hmppsId = "X777776")
 
-  @Test
-  fun `process person alert updated event`() {
-    val eventType = "person.alert.updated"
-    val message = """
-      {"eventType":"$eventType","additionalInformation":{"alertUuid":"8339dd96-4a02-4d5b-bc78-4eda22f678fa","alertCode":"BECTER","source":"NOMIS"},"version":1,"description":"An alert has been created in the alerts service","occurredAt":"2024-08-12T19:48:12.771347283+01:00","detailUrl":"https://alerts-api.hmpps.service.justice.gov.uk/alerts/8339dd96-4a02-4d5b-bc78-4eda22f678fa","personReference":{"identifiers":[{"type":"NOMS","value":"A1234BC"}]}}
-    """.trimIndent()
-    val event = generateHmppsDomainEvent(eventType, message)
-    every { probationIntegrationApiGateway.getPersonIdentifier("A1234BC") } returns PersonIdentifier("X777776", "A1234BC")
-    every { getPrisonIdService.execute("A1234BC") } returns null
     hmppsDomainEventService.execute(event, listOf(IntegrationEventType.PERSON_PND_ALERTS_CHANGED))
+
     verify(exactly = 1) {
       eventNotificationRepository.insertOrUpdate(
         EventNotification(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/IntegrationEventCreationStrategyProviderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/IntegrationEventCreationStrategyProviderTest.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationevents.services
+
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventType
+
+@ActiveProfiles("test")
+class IntegrationEventCreationStrategyProviderTest {
+  private val singleStrategy = mockk<DefaultEventCreationStrategy>(relaxed = true)
+  private val multipleStrategy = mockk<MultipleEventCreationStrategy>(relaxed = true)
+
+  private val strategyProvider = IntegrationEventCreationStrategyProvider(
+    singleEmissionStrategy = singleStrategy,
+    multipleEmissionStrategy = multipleStrategy,
+  )
+
+  @Test
+  fun `should return multipleEmissionStrategy for PRISONER_MERGE`() {
+    val result = strategyProvider.forEventType(IntegrationEventType.PRISONER_MERGE)
+
+    assertThat(multipleStrategy).isEqualTo(result)
+  }
+
+  @Test
+  fun `should return singleEmissionStrategy for other event types`() {
+    val result = strategyProvider.forEventType(IntegrationEventType.CONTACT_CHANGED) // or any non-merge type
+
+    assertThat(singleStrategy).isEqualTo(result)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/MultipleEventCreationStrategyTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/MultipleEventCreationStrategyTest.kt
@@ -1,0 +1,71 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationevents.services
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.tuple
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.SqsNotificationGeneratingHelper
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.HmppsDomainEvent
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventType
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.registration.HmppsDomainEventMessage
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.repository.model.data.EventNotification
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+class MultipleEventCreationStrategyTest {
+
+  private val domainEventIdentitiesResolver = mockk<DomainEventIdentitiesResolver>()
+  private val objectMapper = ObjectMapper()
+  private val hmppsId = "X777776"
+  private val prisonId = "LEI"
+  private val baseUrl = "https://event-service.test"
+  private var eventType = IntegrationEventType.PRISONER_MERGE
+  private val currentTime: LocalDateTime = LocalDateTime.now()
+  private val zonedCurrentDateTime = currentTime.atZone(ZoneId.systemDefault())
+  private var domainMessage = HmppsDomainEventMessage(
+    eventType = eventType.name,
+    occurredAt = "2024-08-13T14:15:16.460942253+01:00",
+    prisonId = prisonId,
+    personReference = null,
+    additionalInformation = null,
+  )
+
+  private lateinit var strategy: MultipleEventCreationStrategy
+
+  @BeforeEach
+  fun setup() {
+    strategy = MultipleEventCreationStrategy(domainEventIdentitiesResolver)
+
+    every { domainEventIdentitiesResolver.getHmppsId(any()) } returns hmppsId
+    every { domainEventIdentitiesResolver.getPrisonId(any()) } returns prisonId
+  }
+
+  @Test
+  fun `should create two notifications with resolved nomsId`() {
+    val nomisNumber = "A1234BC"
+    val removedNomisNumber = "A1234B"
+    val domainEvent: HmppsDomainEvent =
+      SqsNotificationGeneratingHelper(zonedCurrentDateTime).createHmppsMergedDomainEvent(
+        nomisNumber = nomisNumber,
+        removedNomisNumber = removedNomisNumber,
+      )
+    domainMessage = objectMapper.readValue(domainEvent.message)
+
+    val notifications = strategy.createNotifications(domainMessage, eventType, baseUrl)
+
+    assertThat(notifications)
+      .extracting(
+        EventNotification::eventType,
+        EventNotification::hmppsId,
+        EventNotification::url,
+      )
+      .containsExactlyInAnyOrder(
+        tuple(IntegrationEventType.PRISONER_MERGE, nomisNumber, "$baseUrl/v1/persons/$nomisNumber"),
+        tuple(IntegrationEventType.PRISONER_MERGE, removedNomisNumber, "$baseUrl/v1/persons/$removedNomisNumber"),
+      )
+  }
+}


### PR DESCRIPTION
#### Context
Upon receiving prison-offender-events.prisoner.merged domain event, two integration events should be published on SQS

#### Changes proposed in this PR
- Refactored existing logic to introduce a strategy pattern for integration event generation.
- Decoupled service class from multiple concerns (e.g. event generation, fetching of hmppsId and prisonId)