### PR TITLE
[ESWE-1384] remove double slashes from published integration event

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/enums/IntegrationEventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/enums/IntegrationEventType.kt
@@ -436,7 +436,7 @@ enum class IntegrationEventType(
     { PRISONER_EVENTS.contains(it.eventType) },
   ),
   PERSON_EDUCATION_ASSESSMENTS_CHANGED(
-    "/v1/persons/{hmppsId}/education/assessments",
+    "v1/persons/{hmppsId}/education/assessments",
     {
       HmppsDomainEventName.PrisonerOffenderSearch.Prisoner.UPDATED == it.eventType &&
         (

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/listeners/HmppsDomainEventsListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/listeners/HmppsDomainEventsListenerIntegrationTest.kt
@@ -427,7 +427,7 @@ class HmppsDomainEventsListenerIntegrationTest : SqsIntegrationTestBase() {
       savedEvents[3].url.shouldBe("https://localhost:8443/v1/prison/prisoners/$crn")
       savedEvents[4].eventType.shouldBe(IntegrationEventType.PERSON_EDUCATION_ASSESSMENTS_CHANGED)
       savedEvents[4].hmppsId.shouldBe(crn)
-      savedEvents[4].url.shouldBe("https://localhost:8443//v1/persons/$crn/education/assessments")
+      savedEvents[4].url.shouldBe("https://localhost:8443/v1/persons/$crn/education/assessments")
     }
 
     @Test
@@ -476,14 +476,14 @@ class HmppsDomainEventsListenerIntegrationTest : SqsIntegrationTestBase() {
       savedEvents[3].url.shouldBe("https://localhost:8443/v1/prison/prisoners/$crn")
       savedEvents[4].eventType.shouldBe(IntegrationEventType.PERSON_EDUCATION_ASSESSMENTS_CHANGED)
       savedEvents[4].hmppsId.shouldBe(crn)
-      savedEvents[4].url.shouldBe("https://localhost:8443//v1/persons/$crn/education/assessments")
+      savedEvents[4].url.shouldBe("https://localhost:8443/v1/persons/$crn/education/assessments")
     }
 
     @Nested
     @DisplayName("and Education Assessments Integration Event is expected or not.")
     inner class AndEducationAssessmentIntegrationEventIsExpectedOrNot {
       private val intEventType = IntegrationEventType.PERSON_EDUCATION_ASSESSMENTS_CHANGED
-      private val url = "https://localhost:8443//v1/persons/$crn/education/assessments"
+      private val url = "https://localhost:8443/v1/persons/$crn/education/assessments"
 
       @ParameterizedTest
       @MethodSource("$CLASS_QUALIFIED_NAME#educationAssessmentCategoryProvider")


### PR DESCRIPTION


#### Context

- Double slashes in url for PERSON_EDUCATION_ASSESSMENTS_CHANGED integration event.

#### Changes proposed in this PR

- Removed double slashes
- Updated tests