### PR TITLE
HIA-838: Update flyway index script

### DIFF
--- a/src/main/resources/db/migration/V1_0_3__update_indexes.sql
+++ b/src/main/resources/db/migration/V1_0_3__update_indexes.sql
@@ -1,3 +1,10 @@
 CREATE UNIQUE INDEX IF NOT EXISTS idx_event_notification_url_event_type_status ON EVENT_NOTIFICATION(URL, EVENT_TYPE, STATUS);
 
+ALTER TABLE EVENT_NOTIFICATION
+    ADD CONSTRAINT idx_event_notification_url_event_type_status UNIQUE
+    USING INDEX idx_event_notification_url_event_type_status;
+
+ALTER TABLE EVENT_NOTIFICATION
+    DROP CONSTRAINT IF EXISTS idx_event_notification_url_event_type;
+
 DROP INDEX IF EXISTS idx_event_notification_url_event_type;


### PR DESCRIPTION
#### Context
There are currently flyway issues stating the old index cannot be dropped as it is part of a constraint on the table.

The existing index is currently added as a constraint. Therefore the constraint needs to be dropped before droppng the index.
To be consistent, i have also added the new index as a constraint
