### PR TITLE
HIA-838: Changed to use a partial index and added tests

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/repository/EventNotificationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/repository/EventNotificationRepository.kt
@@ -73,12 +73,19 @@ interface EventNotificationRepository : JpaRepository<EventNotification, Long> {
   @Transactional
   @Query(
     """
-    INSERT INTO EventNotification (url, eventType, hmppsId, prisonId, status, lastModifiedDateTime)
-    VALUES (:#{#eventNotification.url}, :#{#eventNotification.eventType}, :#{#eventNotification.hmppsId}, :#{#eventNotification.prisonId}, :#{#eventNotification.status}, :#{#eventNotification.lastModifiedDateTime})
-    ON CONFLICT(url, eventType, status)
-    DO UPDATE SET
-      lastModifiedDateTime = :#{#eventNotification.lastModifiedDateTime}
+    INSERT INTO EVENT_NOTIFICATION (URL, EVENT_TYPE, HMPPS_ID, PRISON_ID, STATUS, LAST_MODIFIED_DATETIME)
+    VALUES (
+      :#{#eventNotification.url},
+      :#{#eventNotification.eventType.name()},
+      :#{#eventNotification.hmppsId},
+      :#{#eventNotification.prisonId},
+      :#{#eventNotification.status.name()},
+      :#{#eventNotification.lastModifiedDateTime}
+    )
+    ON CONFLICT(URL, EVENT_TYPE) WHERE STATUS = 'PENDING' OR STATUS = NULL
+    DO UPDATE SET LAST_MODIFIED_DATETIME = :#{#eventNotification.lastModifiedDateTime}
   """,
+    nativeQuery = true,
   )
   fun insertOrUpdate(
     @Param("eventNotification") eventNotification: EventNotification,

--- a/src/main/resources/db/migration/V1_0_5__update_indexes.sql
+++ b/src/main/resources/db/migration/V1_0_5__update_indexes.sql
@@ -1,0 +1,6 @@
+CREATE UNIQUE INDEX IF NOT EXISTS idx_event_notification_url_event_type ON EVENT_NOTIFICATION(URL, EVENT_TYPE) WHERE STATUS = 'PENDING' OR STATUS = NULL;
+
+ALTER TABLE EVENT_NOTIFICATION
+    DROP CONSTRAINT IF EXISTS idx_event_notification_url_event_type_status;
+
+DROP INDEX IF EXISTS idx_event_notification_url_event_type_status;


### PR DESCRIPTION
#### Context
The unique index is preventing the status of records with the same url and event type to be updated to processed or processing.

#### Changes proposed in this PR
Added a partial index where the unique index only applies for records in the PENDING state or where status is null.

Needed to convert the update to a native query so that ON CONFLICT supports the WHERE clause for partial unique indexes.

Replicated the issue and added a test