### PR TITLE
HIA-838: Enable feature-flag.event-state-management in preprod/prod

### DIFF
--- a/src/main/resources/application-preprod.yml
+++ b/src/main/resources/application-preprod.yml
@@ -28,4 +28,4 @@ subscriber-checker:
     rate: 3600000
 
 feature-flag:
-  event-state-management: false
+  event-state-management: true

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -28,4 +28,4 @@ subscriber-checker:
     rate: 3600000
 
 feature-flag:
-  event-state-management: false
+  event-state-management: true


### PR DESCRIPTION
#### Context

Preparing the deployment of optlock fix for preprod and prod

#### Changes proposed in this PR

Setting feature-flag.event-state-management to true in preprod/prod