### PR TITLE
HIA-912: Do not stop the creation of other events based on one event …

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/exceptions/PrisonNotFoundException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/exceptions/PrisonNotFoundException.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationevents.exceptions
+
+open class PrisonNotFoundException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/enums/IntegrationEventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/models/enums/IntegrationEventType.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums
 
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.exceptions.NotFoundException
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.exceptions.PrisonNotFoundException
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.HmppsDomainEventName
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.HmppsDomainEventName.PrisonOffenderEvents
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.RegisterTypes.CHILD_CONCERNS_CODE
@@ -529,7 +530,7 @@ enum class IntegrationEventType(
     }
     if (replacedPath.contains("{prisonId}")) {
       if (prisonId == null) {
-        throw NotFoundException("Prison ID could not be found in domain event message for path $pathTemplate")
+        throw PrisonNotFoundException("Prison ID could not be found in domain event message for path $pathTemplate")
       }
       replacedPath = replacedPath.replace("{prisonId}", prisonId)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/HmppsDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/HmppsDomainEventService.kt
@@ -2,10 +2,12 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationevents.services
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.exceptions.PrisonNotFoundException
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.HmppsDomainEvent
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventType
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.registration.HmppsDomainEventMessage
@@ -19,13 +21,22 @@ class HmppsDomainEventService(
   @Autowired val integrationEventCreationStrategyProvider: IntegrationEventCreationStrategyProvider,
   @Value("\${services.integration-api.url}") val baseUrl: String,
 ) {
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
   private val objectMapper = ObjectMapper()
 
   fun execute(hmppsDomainEvent: HmppsDomainEvent, integrationEventTypes: List<IntegrationEventType>) {
     val hmppsEvent: HmppsDomainEventMessage = objectMapper.readValue(hmppsDomainEvent.message)
     for (integrationEventType in integrationEventTypes) {
-      val notifications = integrationEventCreationStrategyProvider.forEventType(integrationEventType)
-        .createNotifications(hmppsEvent, integrationEventType, baseUrl)
+      val notifications = try {
+        integrationEventCreationStrategyProvider.forEventType(integrationEventType)
+          .createNotifications(hmppsEvent, integrationEventType, baseUrl)
+      } catch (nfe: PrisonNotFoundException) {
+        log.warn(nfe.message)
+        emptyList()
+      }
       for (notification in notifications) {
         eventNotificationRepository.insertOrUpdate(notification)
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/listeners/NonAssociationEventIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/integration/listeners/NonAssociationEventIntegrationTest.kt
@@ -1,0 +1,102 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.listeners
+
+import io.kotest.matchers.shouldBe
+import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.Awaitility
+import org.awaitility.kotlin.await
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.kotlin.doNothing
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.repository.EventNotificationRepository
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.resources.SqsIntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.resources.wiremock.HmppsAuthExtension
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.resources.wiremock.PrisonerSearchMockServer
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.resources.wiremock.ProbationIntegrationApiExtension
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.services.DeleteProcessedService
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.services.StateEventNotifierService
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.services.SubscriberService
+import java.time.Duration
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@ExtendWith(ProbationIntegrationApiExtension::class, HmppsAuthExtension::class)
+class NonAssociationEventIntegrationTest : SqsIntegrationTestBase() {
+
+  @MockitoBean
+  private lateinit var subscriberService: SubscriberService
+
+  @MockitoBean
+  private lateinit var deleteProcessedService: DeleteProcessedService
+
+  @MockitoBean
+  private lateinit var stateEventNotifierService: StateEventNotifierService
+
+  @Autowired
+  lateinit var repo: EventNotificationRepository
+
+  val nomsNumber = "A1234BD"
+  val crn = "mockCrn"
+  val prisonId = "MDI"
+  val prisonerSearchMockServer = PrisonerSearchMockServer()
+  val awaitTimeOut = Duration.ofSeconds(30)
+  val awaitPollDelay = Duration.ofMillis(200)
+
+  @BeforeEach
+  fun setup() {
+    repo.deleteAll()
+    ProbationIntegrationApiExtension.server.stubGetPersonIdentifier(nomsNumber, crn)
+    prisonerSearchMockServer.start()
+    Awaitility.setDefaultTimeout(awaitTimeOut)
+    Awaitility.setDefaultPollDelay(awaitPollDelay)
+    doNothing().`when`(subscriberService).checkSubscriberFilterList()
+    doNothing().`when`(deleteProcessedService).deleteProcessedEvents()
+    doNothing().`when`(stateEventNotifierService).sentNotifications()
+  }
+
+  @AfterEach
+  fun cleanup() {
+    prisonerSearchMockServer.stop()
+    Awaitility.reset()
+  }
+
+  @Test
+  fun `will not process or save a any event triggered by a prisoner created event where there is no prison id in the response from prisoner search`() {
+    prisonerSearchMockServer.stubGetPrisonerNullPrisonId(nomsNumber)
+    generateRawPersonCreatedEvent().also { sendDomainSqsMessage(it) }
+    Awaitility.await().until { repo.findAll().isNotEmpty() }
+    repo.findAll().size.shouldBe(23)
+    assertThat(getNumberOfMessagesCurrentlyOndomainEventsDeadLetterQueue()).isEqualTo(0)
+  }
+
+  @Test
+  fun `will process or save a all events triggered by a prisoner created event where there is no prison id in the response from prisoner search`() {
+    prisonerSearchMockServer.stubGetPrisoner(nomsNumber)
+    generateRawPersonCreatedEvent().also { sendDomainSqsMessage(it) }
+    Awaitility.await().until { repo.findAll().isNotEmpty() }
+    repo.findAll().size.shouldBe(24)
+    assertThat(getNumberOfMessagesCurrentlyOndomainEventsDeadLetterQueue()).isEqualTo(0)
+  }
+
+  fun generateRawPersonCreatedEvent() = """
+  {
+    "Type" : "Notification",
+    "MessageId" : "eb4a33f3-1b4e-5646-80a9-52b00650b7ff",
+    "TopicArn" : "N/A",
+    "Message" : "{\"additionalInformation\":{\"nomsNumber\":\"A1234BD\"},\"occurredAt\":\"2025-09-16T09:07:56.135238735+01:00\",\"eventType\":\"prisoner-offender-search.prisoner.created\",\"version\":1,\"description\":\"A prisoner record has been created\",\"detailUrl\":\"http://localhost:8080/prisoner/A1234BD\",\"personReference\":{\"identifiers\":[{\"type\":\"NOMS\",\"value\":\"A1234BD\"}]}}",
+    "Timestamp" : "2025-09-16T08:07:58.218Z",
+    "SignatureVersion" : "1",
+    "Signature" : "N/A",
+    "SigningCertURL" : "N/A",
+    "UnsubscribeURL" : "N/A",
+    "MessageAttributes" : {
+      "eventType" : {"Type":"String","Value":"prisoner-offender-search.prisoner.created"}
+    }
+  }  
+  """.trimIndent()
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/resources/wiremock/PrisonerSearchMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/resources/wiremock/PrisonerSearchMockServer.kt
@@ -24,4 +24,24 @@ class PrisonerSearchMockServer internal constructor() : WireMockServer(8446) {
         ),
     )
   }
+
+  fun stubGetPrisonerNullPrisonId(nomsNumber: String) {
+    stubFor(
+      WireMock.get(WireMock.urlEqualTo("/prisoner/$nomsNumber"))
+        .willReturn(
+          WireMock.aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              """
+              {
+                "prisonerNumber": "$nomsNumber",
+                "firstName": "Jane",
+                "lastName": "Smith"
+              }
+              """
+                .trimIndent(),
+            ),
+        ),
+    )
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/DefaultEventCreationStrategyTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/DefaultEventCreationStrategyTest.kt
@@ -14,6 +14,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.exceptions.NotFoundException
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.exceptions.PrisonNotFoundException
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents.PRISONER_OFFENDER_SEARCH_PRISONER_CREATED
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents.PRISONER_OFFENDER_SEARCH_PRISONER_UPDATED
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.integration.helpers.DomainEvents.PROBATION_CASE_ENGAGEMENT_CREATED_MESSAGE
@@ -174,7 +175,7 @@ class DefaultEventCreationStrategyTest {
 
     assertThatThrownBy {
       strategy.createNotifications(domainMessage, eventType, baseUrl)
-    }.isInstanceOf(NotFoundException::class.java)
+    }.isInstanceOf(PrisonNotFoundException::class.java)
       .hasMessage("Prison ID could not be found in domain event message for path v1/prison/{prisonId}/location/{locationKey}")
   }
 


### PR DESCRIPTION
When a `prisoner-offender-search.prisoner.created` event is received by integation-events service.
A look up is performed to create 24 separate notifications

- KEY_DATES_AND_ADJUSTMENTS_PRISONER_RELEASE
- PERSON_STATUS_CHANGED
- PERSON_ADDRESS_CHANGED
- PERSON_CONTACTS_CHANGED
- PERSON_IEP_LEVEL_CHANGED
- PERSON_VISIT_RESTRICTIONS_CHANGED
- PERSON_ALERTS_CHANGED
- PERSON_PND_ALERTS_CHANGED
- PERSON_CASE_NOTES_CHANGED
- PERSON_NAME_CHANGED
- PERSON_CELL_LOCATION_CHANGED
- PERSON_SENTENCES_CHANGED
- PERSON_RESPONSIBLE_OFFICER_CHANGED
- PERSON_PROTECTED_CHARACTERISTICS_CHANGED
- PERSON_REPORTED_ADJUDICATIONS_CHANGED
- PERSON_NUMBER_OF_CHILDREN_CHANGED
- PERSON_PHYSICAL_CHARACTERISTICS_CHANGED
- PERSON_IMAGES_CHANGED
- PRISONERS_CHANGED
- PRISONER_CHANGED
- PRISONER_NON_ASSOCIATIONS_CHANGED
- PERSON_HEALTH_AND_DIET_CHANGED
- PERSON_CARE_NEEDS_CHANGED
- PERSON_LANGUAGES_CHANGED

However, one of these events `PRISONER_NON_ASSOCIATIONS_CHANGED` requires a prison id which is not available at the time we receive the event. 
This prevents ANY of the above events to be created.

This PR will catch this exception and log a warning rather than throwing an exception and not prevent the other 23 events from being created.
