### PR TITLE
HIA-909: Specifically include fields in the event message

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/repository/model/data/EventNotification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/repository/model/data/EventNotification.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationevents.repository.model.data
 
+import com.fasterxml.jackson.annotation.JsonIncludeProperties
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
@@ -18,6 +19,7 @@ import java.time.LocalDateTime
 @Table(
   name = "EVENT_NOTIFICATION",
 )
+@JsonIncludeProperties("eventId", "hmppsId", "eventType", "prisonId", "url", "lastModifiedDateTime")
 data class EventNotification(
 
   @Id

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/IntegrationEventTopicServiceTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationevents/services/IntegrationEventTopicServiceTests.kt
@@ -24,6 +24,7 @@ import software.amazon.awssdk.services.sns.model.PublishRequest
 import software.amazon.awssdk.services.sns.model.PublishResponse
 import software.amazon.awssdk.services.sns.model.SetSubscriptionAttributesRequest
 import software.amazon.awssdk.services.sns.model.Subscription
+import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventStatus
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.models.enums.IntegrationEventType
 import uk.gov.justice.digital.hmpps.hmppsintegrationevents.repository.model.data.EventNotification
 import uk.gov.justice.hmpps.sqs.HmppsQueue
@@ -80,7 +81,7 @@ class IntegrationEventTopicServiceTests(@Autowired private val objectMapper: Obj
 
   @Test
   fun `Publish Event with no prison Id`() {
-    val event = EventNotification(eventId = 123, hmppsId = "hmppsId", eventType = IntegrationEventType.MAPPA_DETAIL_CHANGED, prisonId = null, url = "mockUrl", lastModifiedDateTime = currentTime)
+    val event = EventNotification(eventId = 123, claimId = "claimId", status = IntegrationEventStatus.PROCESSING, hmppsId = "hmppsId", eventType = IntegrationEventType.MAPPA_DETAIL_CHANGED, prisonId = null, url = "mockUrl", lastModifiedDateTime = currentTime)
 
     val response = PublishResponse
       .builder()
@@ -98,6 +99,8 @@ class IntegrationEventTopicServiceTests(@Autowired private val objectMapper: Obj
       JsonAssertions.assertThatJson(payload).node("hmppsId").isEqualTo(event.hmppsId)
       JsonAssertions.assertThatJson(payload).node("prisonId").isEqualTo(event.prisonId)
       JsonAssertions.assertThatJson(payload).node("url").isEqualTo(event.url)
+      JsonAssertions.assertThatJson(payload).node("claimId").isAbsent()
+      JsonAssertions.assertThatJson(payload).node("status").isAbsent()
       Assertions.assertThat(messageAttributes["eventType"])
         .isEqualTo(MessageAttributeValue.builder().stringValue(event.eventType.name).dataType("String").build())
       messageAttributes.shouldNotHaveKey("prisonId")


### PR DESCRIPTION
#### Context
At the moment the entire EventNotification Entity is marshalled to JSON for the payload of the event message.
This means that 'internal' fields (claimId and status) that have subsequently been added to the table, are also being sent (and being ignored).

This PR sets the list of fields to be sent in the message to those specified in the annotation on the EventNotification class
`@JsonIncludeProperties("eventId", "hmppsId", "eventType", "prisonId", "url", "lastModifiedDateTime")`

Thus excluding by default DB fields that have been added for internal reasons.

